### PR TITLE
completionが空文字の際に異常終了する

### DIFF
--- a/frontend/src/hooks/usePostMessageStreaming.ts
+++ b/frontend/src/hooks/usePostMessageStreaming.ts
@@ -33,7 +33,7 @@ const usePostMessageStreaming = create<{
 
           const data = JSON.parse(message.data);
 
-          if (data.completion) {
+          if (data.completion || data.completion === '') {
             if (completion.endsWith('▍')) {
               completion = completion.slice(0, -1);
             }


### PR DESCRIPTION
下記のようなdataが来るときに異常終了するため回避

```json
{
  completion: ''
  stop_reason: stop_sequence
}
```