### PR TITLE
Remove `break-all` class from chat messages

### DIFF
--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -102,7 +102,7 @@ const ChatMessage: React.FC<Props> = (props) => {
 
         <div className="ml-5 grow ">
           {chatContent?.role === 'user' && !isEdit && (
-            <div className="break-all">
+            <div>
               {chatContent.content.body.split('\n').map((c, idx) => (
                 <div key={idx}>{c}</div>
               ))}


### PR DESCRIPTION
This small PR removes the `break-all` class from chat messages, eliminating some ugly wrapping.

Before:
![Before](https://github.com/aws-samples/bedrock-claude-chat/assets/54509200/65f411c5-af51-4e46-9219-933486a0ca17)

After:
![After](https://github.com/aws-samples/bedrock-claude-chat/assets/54509200/32bb1899-ac7a-4c99-865c-3d0462665051)