### PR TITLE
Fix: query pagination

### DIFF
--- a/backend/app/repositories/model.py
+++ b/backend/app/repositories/model.py
@@ -21,3 +21,9 @@ class ConversationModel(BaseModel):
     title: str
     message_map: dict[str, MessageModel]
     last_message_id: str
+
+
+class ConversationMetaModel(BaseModel):
+    id: str
+    title: str
+    create_time: float


### PR DESCRIPTION
[DynamoDB has 1MB limit per query](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.Pagination.html), which can be a limitation when storing extensive conversation histories, as it may prevent the retrieval of all the metadata for multiple records. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
