### PR TITLE
improve the prompt to generate conversation titles

### DIFF
--- a/backend/app/usecase.py
+++ b/backend/app/usecase.py
@@ -166,13 +166,14 @@ def propose_conversation_title(
     user_id: str, conversation_id: str, model="claude"
 ) -> str:
     assert model == "claude", "Only claude model is supported for now."
-    PROMPT = """Please output the subject  to this conversation as the following rule
-    <RULES>
-    - Output is subject only.
-    - Use the language used in the chat
-    - Titles must be no more than 10 tokens
-    </RULES>
-    """
+    PROMPT = """Reading the conversation above, what is the appropriate title for the conversation? When answering the title, please follow the rules below:
+<rules>
+- Title must be in the same language as the conversation.
+- Title length must be from 15 to 20 characters.
+- Prefer more specific title than general. Your title should always be distinct from others.
+- Return the conversation title only. DO NOT include any strings other than the title.
+</rules>
+"""
 
     # Fetch existing conversation
     conversation = find_conversation_by_id(user_id, conversation_id)

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,7 +1,7 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/bedrock-chat.ts",
   "watch": {
-    "include": ["**"],
+    "include": ["**", "../backend"],
     "exclude": [
       "README.md",
       "cdk*.json",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Trying to solve these problems observed with the current prompt:

* Output contains unnecessary annotations (e.g. \<subject\> tag, "Here's the title:", etc.)
* Output is sometimes too long (maybe because 10 tokens means 10 words in English?)
* Output totally ignores the conversation history
* Output is too general 

Also let me add the backend directory to cdk watch target for easier development 🙏 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
