### PR TITLE
fix broken layout on long lines in syntax highlight

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -27,6 +27,7 @@ const Markdown: React.FC<Props> = ({ className, children }) => {
               style={vscDarkPlus}
               language={match[1]}
               PreTag="div"
+              wrapLongLines={true}
             />
           ) : (
             <code {...props} className={className}>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fixes broken layout on long lines in syntax highlight, by enabling wrap lines.

before:
![image](https://github.com/aws-samples/bedrock-claude-chat/assets/7490655/876dc70c-d1c7-4400-9459-4c79477a240b)

after:
![image](https://github.com/aws-samples/bedrock-claude-chat/assets/7490655/65693709-8835-4447-b0df-42176260d641)

prompt to reproduce:
`Output random JavaScript code containing long line with more than 300 characters width.`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
