### PR TITLE
mention us-east-1 explicitly in the model acceess step in README files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add your own instruction and give external knowledge as URL or files (a.k.a [RAG
 
 ## 🚀 Super-easy Deployment
 
-- Open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude`, `Anthropic / Claude Instant` and `Cohere / Embed Multilingual` then `Save changes`.
+- On us-east-1 region, open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude`, `Anthropic / Claude Instant` and `Cohere / Embed Multilingual` then `Save changes`.
 
 <details>
 <summary>Screenshot</summary>

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -23,7 +23,7 @@
 
 ## 🚀 まずはお試し
 
-- [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude`, `Anthropic / Claude Instant`, `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
+- us-east-1リージョンにて、[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude`, `Anthropic / Claude Instant`, `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
 <details>
 <summary>スクリーンショット</summary>
 


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
I thought I followed `Super-easy Deployment` section precisely. However, after the deployment the system did not work as expected. It turned out I used a wrong region when I updated the model access. I understand the link in README is pointing to the right region but some people might not use the link. By explicitly stating the region, the issue can be avioided.
Please note that I do not mean the fix needs to be like this. Feel free to edit, make your own changes, or wait until other people report the same issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
