### PR TITLE
feat: bedrock runtime region param

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -47,11 +47,9 @@ def get_buffer_string(conversations: list[MessageModel]) -> str:
     return "\n\n".join(string_messages)
 
 
-def get_bedrock_client():
-    client = boto3.client("bedrock-runtime", BEDROCK_REGION)
-
+def get_bedrock_client(region=BEDROCK_REGION):
+    client = boto3.client("bedrock-runtime", region)
     return client
-
 
 def get_current_time():
     # Get current time as milliseconds epoch time

--- a/backend/tests/utils/test_utils.py
+++ b/backend/tests/utils/test_utils.py
@@ -1,7 +1,5 @@
 import sys
 import unittest
-import inspect
-from pprint import pformat
 import logging
 
 LOGGER = logging.getLogger(__name__)

--- a/backend/tests/utils/test_utils.py
+++ b/backend/tests/utils/test_utils.py
@@ -1,0 +1,48 @@
+import sys
+import unittest
+import inspect
+from pprint import pformat
+import logging
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+sys.path.append(".")
+
+
+class TestUtils(unittest.TestCase):
+    def test_get_bedrock_client_default(self):
+        from app.utils import get_bedrock_client
+
+        client = get_bedrock_client()
+        assert client is not None
+
+        cli_dict = client.__dict__
+        
+        reg=cli_dict['_client_config'].region_name
+        
+        LOGGER.debug("Region: ")
+        LOGGER.debug(reg)
+
+        assert reg == "us-east-1"
+        
+
+    def test_get_bedrock_client_alt(self):
+        from app.utils import get_bedrock_client
+
+        client = get_bedrock_client("us-west-2")
+        assert client is not None
+
+        cli_dict = client.__dict__
+        
+
+        reg=cli_dict['_client_config'].region_name
+        
+        LOGGER.debug("Region: ")
+        LOGGER.debug(reg)
+
+        assert reg == "us-west-2"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Issue #91 :**

*Description of changes:* Introduces param 'region' that can override BEDROCK_REGION in the case that developer needs to be sure a given region is used.


