### PR TITLE
[Feature] Copy code block to clipboard

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -5,6 +5,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
+import ButtonCopy from './ButtonCopy';
 
 type Props = BaseProps & {
   children: string;
@@ -56,24 +57,6 @@ const CopyToClipboard = ({
       {children}
       <ButtonCopy text={codeText} className="absolute right-2 top-2" />
     </div>
-  );
-};
-
-const ButtonCopy = ({
-  className,
-  text,
-}: {
-  className?: string;
-  text: string;
-}) => {
-  return (
-    <button
-      className={`${className ?? ''} text-gray-500 hover:text-gray-700`}
-      onClick={() => {
-        navigator.clipboard.writeText(text ?? '');
-      }}>
-      Copy
-    </button>
   );
 };
 

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -20,15 +20,19 @@ const Markdown: React.FC<Props> = ({ className, children }) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         code({ node, inline, className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
+          const codeText = String(children).replace(/\n$/, '');
+
           return !inline && match ? (
-            <SyntaxHighlighter
-              {...props}
-              children={String(children).replace(/\n$/, '')}
-              style={vscDarkPlus}
-              language={match[1]}
-              PreTag="div"
-              wrapLongLines={true}
-            />
+            <CopyToClipboard codeText={codeText}>
+              <SyntaxHighlighter
+                {...props}
+                children={codeText}
+                style={vscDarkPlus}
+                language={match[1]}
+                PreTag="div"
+                wrapLongLines={true}
+              />
+            </CopyToClipboard>
           ) : (
             <code {...props} className={className}>
               {children}
@@ -37,6 +41,39 @@ const Markdown: React.FC<Props> = ({ className, children }) => {
         },
       }}
     />
+  );
+};
+
+const CopyToClipboard = ({
+  children,
+  codeText,
+}: {
+  children: React.ReactNode;
+  codeText: string;
+}) => {
+  return (
+    <div className="relative">
+      {children}
+      <ButtonCopy text={codeText} className="absolute right-2 top-2" />
+    </div>
+  );
+};
+
+const ButtonCopy = ({
+  className,
+  text,
+}: {
+  className?: string;
+  text: string;
+}) => {
+  return (
+    <button
+      className={`${className ?? ''} text-gray-500 hover:text-gray-700`}
+      onClick={() => {
+        navigator.clipboard.writeText(text ?? '');
+      }}>
+      Copy
+    </button>
   );
 };
 


### PR DESCRIPTION
コードブロックをクリップボードにコピーする機能を追加
[2024/3/7] 件名を英語に変更させていただきました。@wadabee

*Issue #, if available:*

*Description of changes:*
Copyボタン押下でソースコードの範囲がクリップボードにコピーされます
<img width="137" alt="スクリーンショット 2024-03-06 15 13 15" src="https://github.com/aws-samples/bedrock-claude-chat/assets/114975044/5191b795-1ac6-480d-b305-56b98bc4424c">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
