### PR TITLE
Fix "retrieving" typo in labels

### DIFF
--- a/frontend/src/hooks/usePostMessageStreaming.ts
+++ b/frontend/src/hooks/usePostMessageStreaming.ts
@@ -15,7 +15,7 @@ const usePostMessageStreaming = create<{
   return {
     post: async ({ input, dispatch, hasKnowledge }) => {
       if (hasKnowledge) {
-        dispatch(i18next.t('bot.label.retrivingKnowledge'));
+        dispatch(i18next.t('bot.label.retrievingKnowledge'));
       } else {
         dispatch(i18next.t('app.chatWaitingSymbol'));
       }

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -24,7 +24,7 @@ const translation = {
         notAvailable: 'This bot is NOT available.',
         noBots: 'No Bots.',
         noBotsRecentlyUsed: 'No Recently Used Shared Bots.',
-        retrivingKnowledge: '[Retriving Knowledge...]',
+        retrievingKnowledge: '[Retrieving Knowledge...]',
         dndFileUpload:
           'You can upload files by drag and drop.\nSupported files: {{fileExtensions}}',
         uploadError: 'Error Message',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -27,7 +27,7 @@ const translation = {
         notAvailable: 'このボットは利用できません。',
         noBots: 'ボットが登録されていません。',
         noBotsRecentlyUsed: '最近利用した公開ボットはありません。',
-        retrivingKnowledge: '[ナレッジを取得中...]',
+        retrievingKnowledge: '[ナレッジを取得中...]',
         dndFileUpload:
           'ドラッグ＆ドロップでファイルをアップロードできます。\n対応ファイル: {{fileExtensions}}',
         uploadError: 'エラーメッセージ',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Retrieving was spelled without the "e" in the UI. Fixed it everywhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
