### PR TITLE
reduce task startup time for embedding job

### DIFF
--- a/backend/embedding.Dockerfile
+++ b/backend/embedding.Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /src
 COPY ./embedding.requirements.txt ./requirements.txt
 RUN pip3 install -r requirements.txt --no-cache-dir
 
-RUN playwright install
+RUN playwright install chromium
 
 COPY ./embedding ./embedding
 COPY ./app ./app

--- a/cdk/.prettierrc
+++ b/cdk/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 80
+}

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -2102,9 +2102,9 @@
       }
     },
     "node_modules/deploy-time-build": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/deploy-time-build/-/deploy-time-build-0.3.2.tgz",
-      "integrity": "sha512-nC3rQgJbhjUkrGSsGzsLKmkLgIum9tgyXtVzj7Dnkx+Sn68ec90mtSo9bm9rsBXfzXY77RhbBZ+02oSjopWMbA==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/deploy-time-build/-/deploy-time-build-0.3.15.tgz",
+      "integrity": "sha512-LRIea3aH0rxTaicSh3Nz6Fk77r1xAg9Hfl2AnBMq6JTG9LYCbOlMcuSKxNB4EGiyiJ4EkG3UJXCPFXjFuifMmA==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.38.0",
         "constructs": "^10.0.5"
@@ -3699,6 +3699,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

What I did: 

* Enable SOCI index
* install only chromium for playwright

Result:
* Image size is reduced by 200MB(compressed)
* Task startup is reduced by 80%

I also added `.prettierrc` for consistent formatting, following the current format rule (I guess).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
