### PR TITLE
fix[240]: chat history language through prompt order

### DIFF
--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -357,10 +357,10 @@ def propose_conversation_title(
 ) -> str:
     PROMPT = """Reading the conversation above, what is the appropriate title for the conversation? When answering the title, please follow the rules below:
 <rules>
-- Title must be in the same language as the conversation.
 - Title length must be from 15 to 20 characters.
 - Prefer more specific title than general. Your title should always be distinct from others.
 - Return the conversation title only. DO NOT include any strings other than the title.
+- Title must be in the same language as the conversation.
 </rules>
 """
     # Fetch existing conversation


### PR DESCRIPTION
*Issue #, if available:* 
#240 

*Description of changes:*
When using application in English, chat history shows as Spanish as described in issue #240.

Changing prompt rule ordering used to determine chat history title. Moved `- Title must be in the same language as the conversation.` to end.

Before fix:
![image](https://github.com/aws-samples/bedrock-claude-chat/assets/41482534/a916ab8d-59f9-4ed8-adc1-f519e23be335)

After fix:
![image](https://github.com/aws-samples/bedrock-claude-chat/assets/41482534/ce6d045f-0958-45d1-8ae5-c2377c83df29)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
