### PR TITLE
Add Support for Claude 3 Opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Analyze usage for each user / bot on administrator dashboard. [detail](./docs/AD
 
 ## 🚀 Super-easy Deployment
 
-- In the us-east-1 region, open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet`, `Anthropic / Claude 3 Opus` and `Cohere / Embed Multilingual` then `Save changes`.
+- In the us-east-1 region, open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet` and `Cohere / Embed Multilingual` then `Save changes`.
 
 <details>
 <summary>Screenshot</summary>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is a sample chatbot using the Anthropic company's LLM [Claude](h
 
 ### Basic Conversation
 
-Not only text but also images are available with [Anthropic's Claude 3](https://www.anthropic.com/news/claude-3-family). Currently we support `Haiku` and `Sonnet`.
+Not only text but also images are available with [Anthropic's Claude 3](https://www.anthropic.com/news/claude-3-family). Currently we support `Haiku`, `Sonnet` and `Opus`.
 
 ![](./docs/imgs/demo.gif)
 
@@ -41,7 +41,7 @@ Analyze usage for each user / bot on administrator dashboard. [detail](./docs/AD
 
 ## 🚀 Super-easy Deployment
 
-- In the us-east-1 region, open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet` and `Cohere / Embed Multilingual` then `Save changes`.
+- In the us-east-1 region, open [Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > Check `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet`, `Anthropic / Claude 3 Opus` and `Cohere / Embed Multilingual` then `Save changes`.
 
 <details>
 <summary>Screenshot</summary>

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -89,6 +89,8 @@ def get_model_id(model: str) -> str:
         return "anthropic.claude-3-sonnet-20240229-v1:0"
     elif model == "claude-v3-haiku":
         return "anthropic.claude-3-haiku-20240307-v1:0"
+    elif model == "claude-v3-opus":
+        return "anthropic.claude-3-opus-20240229-v1:0"
     else:
         raise NotImplementedError()
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -66,6 +66,7 @@ ANTHROPIC_PRICING = {
             "output": 0.00240,
         },
         "claude-v3-sonnet": {"input": 0.00300, "output": 0.01500},
+        "claude-v3-opus": {"input": 0.01500, "output": 0.07500},
     },
     "ap-northeast-1": {
         "claude-instant-v1": {
@@ -88,5 +89,6 @@ ANTHROPIC_PRICING = {
         },
         "claude-v3-haiku": {"input": 0.00025, "output": 0.00125},
         "claude-v3-sonnet": {"input": 0.00300, "output": 0.01500},
+        "claude-v3-opus": {"input": 0.01500, "output": 0.07500},
     },
 }

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -4,7 +4,7 @@ from app.routes.schemas.base import BaseSchema
 from pydantic import Field
 
 type_model_name = Literal[
-    "claude-instant-v1", "claude-v2", "claude-v3-sonnet", "claude-v3-haiku"
+    "claude-instant-v1", "claude-v2", "claude-v3-sonnet", "claude-v3-haiku", "claude-v3-opus"
 ]
 
 

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -352,7 +352,7 @@ def propose_conversation_title(
     user_id: str,
     conversation_id: str,
     model: Literal[
-        "claude-instant-v1", "claude-v2", "claude-v3-sonnet", "claude-v3-haiku"
+        "claude-instant-v1", "claude-v2", "claude-v3-opus", "claude-v3-sonnet", "claude-v3-haiku"
     ] = "claude-v3-haiku",
 ) -> str:
     PROMPT = """Reading the conversation above, what is the appropriate title for the conversation? When answering the title, please follow the rules below:

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -12,7 +12,7 @@
 
 ### 基本的な会話
 
-[Claude 3](https://www.anthropic.com/news/claude-3-family)によるテキストと画像の両方を利用したチャットが可能です。現在`Haiku`および`Sonnet`をサポートしています。
+[Claude 3](https://www.anthropic.com/news/claude-3-family)によるテキストと画像の両方を利用したチャットが可能です。現在`Haiku`および`Sonnet`、まだは`Opus`をサポートしています。
 ![](./imgs/demo_ja.gif)
 
 ### ボットのカスタマイズ
@@ -31,7 +31,7 @@
 
 ## 🚀 まずはお試し
 
-- us-east-1 リージョンにて、[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet`, `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
+- us-east-1 リージョンにて、[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet`, `Anthropic / Claude 3 Opus`, `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
 
 <details>
 <summary>スクリーンショット</summary>

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -31,7 +31,7 @@
 
 ## 🚀 まずはお試し
 
-- us-east-1 リージョンにて、[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet`, `Anthropic / Claude 3 Opus`, `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
+- us-east-1 リージョンにて、[Bedrock Model access](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) > `Manage model access` > `Anthropic / Claude 3 Haiku`, `Anthropic / Claude 3 Sonnet` `Cohere / Embed Multilingual`をチェックし、`Save changes`をクリックします
 
 <details>
 <summary>スクリーンショット</summary>

--- a/frontend/src/@types/conversation.d.ts
+++ b/frontend/src/@types/conversation.d.ts
@@ -2,6 +2,7 @@ export type Role = 'system' | 'assistant' | 'user';
 export type Model =
   | 'claude-instant-v1'
   | 'claude-v2'
+  | 'claude-v3-opus'
   | 'claude-v3-sonnet'
   | 'claude-v3-haiku';
 export type Content = {

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -17,6 +17,11 @@ const availableModels: {
     label: 'Claude 3 (Sonnet)',
     supportMediaType: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
   },
+  {
+    modelId: 'claude-v3-opus',
+    label: 'Claude 3 (Opus)',
+    supportMediaType: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+  },
 ];
 
 const useModelState = create<{


### PR DESCRIPTION
*Description of changes:*

Add support for latest Claude 3 Opus.

It is noted that [Opus is only available in `us-west-2` now](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html#:~:text=Anthropic%20Claude%203%20Opus%20is%20only%20available%20in%20US%20West%20(Oregon%2C%20us%2Dwest%2D2).), it's reflected in `backend/app/config.py`.

https://aws.amazon.com/blogs/aws/anthropics-claude-3-opus-model-on-amazon-bedrock/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
