### PR TITLE
Fix: glue schema for messageMap

### DIFF
--- a/cdk/lib/constructs/usage-analysis.ts
+++ b/cdk/lib/constructs/usage-analysis.ts
@@ -78,7 +78,7 @@ export class UsageAnalysis extends Construct {
       },
       {
         name: "MessageMap",
-        type: glue.Schema.STRING,
+        type: glue.Schema.struct([{ name: "S", type: glue.Schema.STRING }]),
       },
       {
         name: "PK",

--- a/docs/ADMINISTRATOR.md
+++ b/docs/ADMINISTRATOR.md
@@ -37,7 +37,7 @@ Edit `bot-id` and `datehour`. `bot-id` can be referred on Bot Management screen,
 SELECT
     d.newimage.PK.S AS UserId,
     d.newimage.SK.S AS ConversationId,
-    d.newimage.MessageMap AS MessageMap,
+    d.newimage.MessageMap.S AS MessageMap,
     d.newimage.TotalPrice.N AS TotalPrice,
     d.newimage.CreateTime.N AS CreateTime,
     d.newimage.LastMessageId.S AS LastMessageId,
@@ -64,7 +64,7 @@ Edit `user-id` and `datehour`. `user-id` can be referred on Bot Management scree
 SELECT
     d.newimage.PK.S AS UserId,
     d.newimage.SK.S AS ConversationId,
-    d.newimage.MessageMap AS MessageMap,
+    d.newimage.MessageMap.S AS MessageMap,
     d.newimage.TotalPrice.N AS TotalPrice,
     d.newimage.CreateTime.N AS CreateTime,
     d.newimage.LastMessageId.S AS LastMessageId,


### PR DESCRIPTION
*Issue #, if available:*
Modify `messageMap` schema for athena query so that user can filter by attribute of messageMap

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
