### PR TITLE
If there are no updates to the knowledge in the bot console, skip embedding

### DIFF
--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -59,7 +59,7 @@ class BotModifyInput(BaseSchema):
         if self.has_update_files():
             return True
 
-        if self.knowledge is not None and current_bot_model.knowledge is not None:
+        if self.knowledge is not None and current_bot_model.has_knowledge():
             if set(self.knowledge.source_urls) == set(
                 current_bot_model.knowledge.source_urls
             ) and set(self.knowledge.sitemap_urls) == set(

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -1,7 +1,13 @@
-from typing import Literal
-
+from __future__ import annotations
+from typing import (
+  Literal,
+  TYPE_CHECKING
+)
 from app.routes.schemas.base import BaseSchema
 from pydantic import Field
+
+if TYPE_CHECKING:
+    from app.repositories.models.custom_bot import BotModel
 
 # Knowledge sync status type
 # NOTE: `ORIGINAL_NOT_FOUND` is used when the original bot is removed.
@@ -52,26 +58,38 @@ class BotModifyInput(BaseSchema):
             or len(self.knowledge.deleted_filenames) > 0
         )
 
-    def is_embedding_required(self, current_bot_model) -> bool:
+    def is_embedding_required(self, current_bot_model: BotModel) -> bool:
+        if self.has_update_files(): return True
+
         if (
             self.knowledge is not None
             and current_bot_model.knowledge is not None
-            and set(self.knowledge.source_urls)
-            == set(current_bot_model.knowledge.source_urls)
-            and set(self.knowledge.sitemap_urls)
-            == set(current_bot_model.knowledge.sitemap_urls)
-            and self.embedding_params is not None
-            and current_bot_model.embedding_params is not None
-            and self.embedding_params.chunk_size
-            == current_bot_model.embedding_params.chunk_size
-            and self.embedding_params.chunk_overlap
-            == current_bot_model.embedding_params.chunk_overlap
-            and self.has_update_files() is False
-        ):
-            return False
-        else:
-            return True
+        ): 
+            if (
+                set(self.knowledge.source_urls)
+                == set(current_bot_model.knowledge.source_urls)
+                and set(self.knowledge.sitemap_urls)
+                == set(current_bot_model.knowledge.sitemap_urls)
+            ):
+                pass
+            else: 
+                return True
 
+        if (
+            self.embedding_params is not None
+            and current_bot_model.embedding_params is not None
+        ):
+            if (
+                self.embedding_params.chunk_size
+                == current_bot_model.embedding_params.chunk_size
+                and self.embedding_params.chunk_overlap
+                == current_bot_model.embedding_params.chunk_overlap
+            ):
+                pass
+            else: 
+                return True
+
+        return False
 
 class BotModifyOutput(BaseSchema):
     id: str

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -46,31 +46,32 @@ class BotModifyInput(BaseSchema):
     embedding_params: EmbeddingParams | None
     knowledge: KnowledgeDiffInput | None
 
-    def has_update_files(self) -> bool: 
-        return (
-            self.knowledge is not None
-            and (
-                len(self.knowledge.added_filenames) > 0 
-                or len(self.knowledge.deleted_filenames) > 0
-            )
+    def has_update_files(self) -> bool:
+        return self.knowledge is not None and (
+            len(self.knowledge.added_filenames) > 0
+            or len(self.knowledge.deleted_filenames) > 0
         )
 
     def is_embedding_required(self, current_bot_model) -> bool:
         if (
             self.knowledge is not None
             and current_bot_model.knowledge is not None
-            and set(self.knowledge.source_urls) == set(current_bot_model.knowledge.source_urls)
-            and set(self.knowledge.sitemap_urls) == set(current_bot_model.knowledge.sitemap_urls)
+            and set(self.knowledge.source_urls)
+            == set(current_bot_model.knowledge.source_urls)
+            and set(self.knowledge.sitemap_urls)
+            == set(current_bot_model.knowledge.sitemap_urls)
             and self.embedding_params is not None
             and current_bot_model.embedding_params is not None
-            and self.embedding_params.chunk_size == current_bot_model.embedding_params.chunk_size
-            and self.embedding_params.chunk_overlap == current_bot_model.embedding_params.chunk_overlap
+            and self.embedding_params.chunk_size
+            == current_bot_model.embedding_params.chunk_size
+            and self.embedding_params.chunk_overlap
+            == current_bot_model.embedding_params.chunk_overlap
             and self.has_update_files() is False
         ):
             return False
         else:
             return True
-        
+
 
 class BotModifyOutput(BaseSchema):
     id: str

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
-from typing import (
-  Literal,
-  TYPE_CHECKING
-)
+from typing import Literal, TYPE_CHECKING
 from app.routes.schemas.base import BaseSchema
 from pydantic import Field
 
@@ -59,20 +56,17 @@ class BotModifyInput(BaseSchema):
         )
 
     def is_embedding_required(self, current_bot_model: BotModel) -> bool:
-        if self.has_update_files(): return True
+        if self.has_update_files():
+            return True
 
-        if (
-            self.knowledge is not None
-            and current_bot_model.knowledge is not None
-        ): 
-            if (
-                set(self.knowledge.source_urls)
-                == set(current_bot_model.knowledge.source_urls)
-                and set(self.knowledge.sitemap_urls)
-                == set(current_bot_model.knowledge.sitemap_urls)
+        if self.knowledge is not None and current_bot_model.knowledge is not None:
+            if set(self.knowledge.source_urls) == set(
+                current_bot_model.knowledge.source_urls
+            ) and set(self.knowledge.sitemap_urls) == set(
+                current_bot_model.knowledge.sitemap_urls
             ):
                 pass
-            else: 
+            else:
                 return True
 
         if (
@@ -86,10 +80,11 @@ class BotModifyInput(BaseSchema):
                 == current_bot_model.embedding_params.chunk_overlap
             ):
                 pass
-            else: 
+            else:
                 return True
 
         return False
+
 
 class BotModifyOutput(BaseSchema):
     id: str

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -46,6 +46,31 @@ class BotModifyInput(BaseSchema):
     embedding_params: EmbeddingParams | None
     knowledge: KnowledgeDiffInput | None
 
+    def has_update_files(self) -> bool: 
+        return (
+            self.knowledge is not None
+            and (
+                len(self.knowledge.added_filenames) > 0 
+                or len(self.knowledge.deleted_filenames) > 0
+            )
+        )
+
+    def is_embedding_required(self, current_bot_model) -> bool:
+        if (
+            self.knowledge is not None
+            and current_bot_model.knowledge is not None
+            and set(self.knowledge.source_urls) == set(current_bot_model.knowledge.source_urls)
+            and set(self.knowledge.sitemap_urls) == set(current_bot_model.knowledge.sitemap_urls)
+            and self.embedding_params is not None
+            and current_bot_model.embedding_params is not None
+            and self.embedding_params.chunk_size == current_bot_model.embedding_params.chunk_size
+            and self.embedding_params.chunk_overlap == current_bot_model.embedding_params.chunk_overlap
+            and self.has_update_files() is False
+        ):
+            return False
+        else:
+            return True
+        
 
 class BotModifyOutput(BaseSchema):
     id: str

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -211,11 +211,7 @@ def modify_owned_bot(
     # 'sync_status = "QUEUED"' will execute embeding process and update dynamodb record.
     # 'sync_status= "SUCCEEDED"' will update only dynamodb record.
     bot = find_private_bot_by_id(user_id, bot_id)
-    sync_status = (
-        "QUEUED"
-        if modify_input.is_embedding_required(bot)
-        else "SUCCEEDED"
-    )
+    sync_status = "QUEUED" if modify_input.is_embedding_required(bot) else "SUCCEEDED"
 
     update_bot(
         user_id,

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -212,24 +212,9 @@ def modify_owned_bot(
     # 'sync_status= "SUCCEEDED"' will update only dynamodb record.
     bot = find_private_bot_by_id(user_id, bot_id)
     sync_status = (
-        "SUCCEEDED"
-        if (
-            modify_input.knowledge is not None
-            and bot.knowledge is not None
-            and sorted(modify_input.knowledge.source_urls)
-            == sorted(bot.knowledge.source_urls)
-            and sorted(modify_input.knowledge.sitemap_urls)
-            == sorted(bot.knowledge.sitemap_urls)
-            and len(modify_input.knowledge.added_filenames) == 0
-            and len(modify_input.knowledge.deleted_filenames) == 0
-            and modify_input.embedding_params is not None
-            and bot.embedding_params is not None
-            and modify_input.embedding_params.chunk_size
-            == bot.embedding_params.chunk_size
-            and modify_input.embedding_params.chunk_overlap
-            == bot.embedding_params.chunk_overlap
-        )
-        else "QUEUED"
+        "QUEUED"
+        if modify_input.is_embedding_required(bot)
+        else "SUCCEEDED"
     )
 
     update_bot(

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -172,7 +172,7 @@ def modify_owned_bot(
     source_urls = []
     sitemap_urls = []
     filenames = []
-    sync_status="QUEUED"
+    sync_status: type_sync_status = "QUEUED"
 
     if modify_input.knowledge:
         source_urls = modify_input.knowledge.source_urls
@@ -211,16 +211,23 @@ def modify_owned_bot(
     # 'sync_status = "QUEUED"' will execute embeding process and update dynamodb record.
     # 'sync_status= "SUCCEEDED"' will update only dynamodb record.
     bot = find_private_bot_by_id(user_id, bot_id)
+    sync_status = (
+    "SUCCEEDED"
     if (
-        (sorted(modify_input.knowledge.source_urls) == sorted(bot.knowledge.source_urls)) and 
-        (sorted(modify_input.knowledge.sitemap_urls) == sorted(bot.knowledge.sitemap_urls)) and 
-        (len(modify_input.knowledge.added_filenames)==0) and 
-        (len(modify_input.knowledge.deleted_filenames)==0) and 
-        (modify_input.embedding_params.chunk_size == bot.embedding_params.chunk_size) and 
-        (modify_input.embedding_params.chunk_overlap == bot.embedding_params.chunk_overlap)
-    ):
-        sync_status="SUCCEEDED"
-        
+        modify_input.knowledge is not None
+        and bot.knowledge is not None
+        and sorted(modify_input.knowledge.source_urls) == sorted(bot.knowledge.source_urls)
+        and sorted(modify_input.knowledge.sitemap_urls) == sorted(bot.knowledge.sitemap_urls)
+        and len(modify_input.knowledge.added_filenames) == 0
+        and len(modify_input.knowledge.deleted_filenames) == 0
+        and modify_input.embedding_params is not None
+        and bot.embedding_params is not None
+        and modify_input.embedding_params.chunk_size == bot.embedding_params.chunk_size
+        and modify_input.embedding_params.chunk_overlap == bot.embedding_params.chunk_overlap
+    )
+        else "QUEUED"
+    )
+
     update_bot(
         user_id,
         bot_id,

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -212,19 +212,23 @@ def modify_owned_bot(
     # 'sync_status= "SUCCEEDED"' will update only dynamodb record.
     bot = find_private_bot_by_id(user_id, bot_id)
     sync_status = (
-    "SUCCEEDED"
-    if (
-        modify_input.knowledge is not None
-        and bot.knowledge is not None
-        and sorted(modify_input.knowledge.source_urls) == sorted(bot.knowledge.source_urls)
-        and sorted(modify_input.knowledge.sitemap_urls) == sorted(bot.knowledge.sitemap_urls)
-        and len(modify_input.knowledge.added_filenames) == 0
-        and len(modify_input.knowledge.deleted_filenames) == 0
-        and modify_input.embedding_params is not None
-        and bot.embedding_params is not None
-        and modify_input.embedding_params.chunk_size == bot.embedding_params.chunk_size
-        and modify_input.embedding_params.chunk_overlap == bot.embedding_params.chunk_overlap
-    )
+        "SUCCEEDED"
+        if (
+            modify_input.knowledge is not None
+            and bot.knowledge is not None
+            and sorted(modify_input.knowledge.source_urls)
+            == sorted(bot.knowledge.source_urls)
+            and sorted(modify_input.knowledge.sitemap_urls)
+            == sorted(bot.knowledge.sitemap_urls)
+            and len(modify_input.knowledge.added_filenames) == 0
+            and len(modify_input.knowledge.deleted_filenames) == 0
+            and modify_input.embedding_params is not None
+            and bot.embedding_params is not None
+            and modify_input.embedding_params.chunk_size
+            == bot.embedding_params.chunk_size
+            and modify_input.embedding_params.chunk_overlap
+            == bot.embedding_params.chunk_overlap
+        )
         else "QUEUED"
     )
 


### PR DESCRIPTION
*Issue #, if available:*
#268 

*Description of changes:*
Compare the update details given from the screen with knowledge, chunk_size, and chunk_overlap stored in dynamodb, and add a process to skip the emnbedding process if there are no changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
