### PR TITLE
feat: when enableMistral, the app name from frontend UI updates

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,13 +15,14 @@ const customProviderEnabled =
 const socialProviderFromEnv = import.meta.env.VITE_APP_SOCIAL_PROVIDERS?.split(
   ','
 ).filter(validateSocialProvider);
+const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
 const App: React.FC = () => {
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
     // set header title
-    document.title = t('app.name');
+    document.title = !mistralEnabled ? t('app.name'): t('app.nameWithoutClaude');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,14 +15,14 @@ const customProviderEnabled =
 const socialProviderFromEnv = import.meta.env.VITE_APP_SOCIAL_PROVIDERS?.split(
   ','
 ).filter(validateSocialProvider);
-const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+const MISTRAL_ENABLED: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
 const App: React.FC = () => {
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
     // set header title
-    document.title = !mistralEnabled ? t('app.name'): t('app.nameWithoutClaude');
+    document.title = !MISTRAL_ENABLED ? t('app.name') : t('app.nameWithoutClaude');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/components/AuthAmplify.tsx
+++ b/frontend/src/components/AuthAmplify.tsx
@@ -13,13 +13,14 @@ type Props = BaseProps & {
 const AuthAmplify: React.FC<Props> = ({ socialProviders, children }) => {
   const { t } = useTranslation();
   const { signOut } = useAuthenticator();
+  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
   return (
     <Authenticator
       socialProviders={socialProviders}
       components={{
         Header: () => (
           <div className="mb-5 mt-10 flex justify-center text-3xl text-aws-font-color">
-            {t('app.name')}
+            {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
           </div>
         ),
       }}>

--- a/frontend/src/components/AuthAmplify.tsx
+++ b/frontend/src/components/AuthAmplify.tsx
@@ -5,6 +5,8 @@ import { SocialProvider } from '@aws-amplify/ui';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 
+const MISTRAL_ENABLED: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+
 type Props = BaseProps & {
   socialProviders: SocialProvider[];
   children: ReactNode;
@@ -13,14 +15,14 @@ type Props = BaseProps & {
 const AuthAmplify: React.FC<Props> = ({ socialProviders, children }) => {
   const { t } = useTranslation();
   const { signOut } = useAuthenticator();
-  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+
   return (
     <Authenticator
       socialProviders={socialProviders}
       components={{
         Header: () => (
           <div className="mb-5 mt-10 flex justify-center text-3xl text-aws-font-color">
-            {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
+            {!MISTRAL_ENABLED ? t('app.name') : t('app.nameWithoutClaude')}
           </div>
         ),
       }}>

--- a/frontend/src/components/AuthCustom.tsx
+++ b/frontend/src/components/AuthCustom.tsx
@@ -19,6 +19,7 @@ const AuthCustom: React.FC<Props> = ({ children }) => {
   const [authenticated, setAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
   const { t } = useTranslation();
+  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
   useEffect(() => {
     Auth.currentAuthenticatedUser()
@@ -55,7 +56,7 @@ const AuthCustom: React.FC<Props> = ({ children }) => {
       ) : !authenticated ? (
         <div className="flex flex-col items-center gap-4">
           <div className="mb-5 mt-10 text-4xl text-aws-sea-blue">
-            {t('app.name')}
+            {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
           </div>
           <Button onClick={() => signIn()} className="px-20 text-xl">
             {t('signIn.button.login')}

--- a/frontend/src/components/AuthCustom.tsx
+++ b/frontend/src/components/AuthCustom.tsx
@@ -11,6 +11,8 @@ import { Auth } from 'aws-amplify';
 import { useTranslation } from 'react-i18next';
 import { PiCircleNotch } from 'react-icons/pi';
 
+const MISTRAL_ENABLED: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+
 type Props = BaseProps & {
   children: ReactNode;
 };
@@ -19,7 +21,6 @@ const AuthCustom: React.FC<Props> = ({ children }) => {
   const [authenticated, setAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
   const { t } = useTranslation();
-  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
   useEffect(() => {
     Auth.currentAuthenticatedUser()
@@ -56,7 +57,7 @@ const AuthCustom: React.FC<Props> = ({ children }) => {
       ) : !authenticated ? (
         <div className="flex flex-col items-center gap-4">
           <div className="mb-5 mt-10 text-4xl text-aws-sea-blue">
-            {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
+            {!MISTRAL_ENABLED ? t('app.name') : t('app.nameWithoutClaude')}
           </div>
           <Button onClick={() => signIn()} className="px-20 text-xl">
             {t('signIn.button.login')}

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -36,7 +36,7 @@ const availableModels: {
     },
     {
       modelId: 'mistral-large',
-      label: 'Mixtral Large',
+      label: 'Mistral Large',
       supportMediaType: [],
     },
   ]

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -2,12 +2,12 @@ import { create } from 'zustand';
 import { Model } from '../@types/conversation';
 import { useMemo } from 'react';
 
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+const MISTRAL_ENABLED: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const availableModels: {
   modelId: Model;
   label: string;
   supportMediaType: string[];
-}[] = !ENABLE_MISTRAL ? [
+}[] = !MISTRAL_ENABLED ? [
   {
     modelId: 'claude-v3-haiku',
     label: 'Claude 3 (Haiku)',

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -1,7 +1,8 @@
+const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: 'Bedrock Claude Chat',
+      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
       inputMessage: 'Nachricht senden',
       starredBots: 'Favorisierte Bots',
       recentlyUsedBots: 'Zuletzt genutzte Bots',

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -1,8 +1,8 @@
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+      name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: 'Nachricht senden',
       starredBots: 'Favorisierte Bots',
       recentlyUsedBots: 'Zuletzt genutzte Bots',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,3 +1,4 @@
+const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     signIn: {
@@ -6,7 +7,7 @@ const translation = {
       },
     },
     app: {
-      name: 'Bedrock Claude Chat',
+      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
       inputMessage: 'Send a message',
       starredBots: 'Starred Bots',
       recentlyUsedBots: 'Recently Used Bots',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -1,4 +1,3 @@
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     signIn: {
@@ -7,7 +6,8 @@ const translation = {
       },
     },
     app: {
-      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+      name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: 'Send a message',
       starredBots: 'Starred Bots',
       recentlyUsedBots: 'Recently Used Bots',

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -7,6 +7,7 @@ const translation = {
     },
     app: {
       name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: 'Enviar un mensaje',
       starredBots: 'Bots Favoritos',
       recentlyUsedBots: 'Bots Usados Recientemente',

--- a/frontend/src/i18n/fr/index.ts
+++ b/frontend/src/i18n/fr/index.ts
@@ -1,7 +1,8 @@
+const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: 'Bedrock Claude Chat',
+      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
       inputMessage: 'Envoyer un message',
       starredBots: 'Epingler un bot',
       recentlyUsedBots: 'Bot utilisé récemment',

--- a/frontend/src/i18n/fr/index.ts
+++ b/frontend/src/i18n/fr/index.ts
@@ -1,8 +1,8 @@
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+      name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: 'Envoyer un message',
       starredBots: 'Epingler un bot',
       recentlyUsedBots: 'Bot utilisé récemment',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -1,6 +1,7 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
+const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     signIn: {
@@ -9,7 +10,7 @@ const translation = {
       },
     },
     app: {
-      name: 'Bedrock Claude Chat',
+      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
       inputMessage: '入力してください',
       starredBots: 'スター付きのボット',
       recentlyUsedBots: '最近使用したボット',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -1,7 +1,6 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     signIn: {
@@ -10,7 +9,8 @@ const translation = {
       },
     },
     app: {
-      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+      name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: '入力してください',
       starredBots: 'スター付きのボット',
       recentlyUsedBots: '最近使用したボット',

--- a/frontend/src/i18n/ko/index.ts
+++ b/frontend/src/i18n/ko/index.ts
@@ -1,10 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
+const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: 'Bedrock Claude Chat',
+      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
       inputMessage: '입력해 주십시오',
     },
     deleteDialog: {

--- a/frontend/src/i18n/ko/index.ts
+++ b/frontend/src/i18n/ko/index.ts
@@ -1,11 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
-const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 const translation = {
   translation: {
     app: {
-      name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+      name: 'Bedrock Claude Chat',
+      nameWithoutClaude: 'Bedrock Chat',
       inputMessage: '입력해 주십시오',
     },
     deleteDialog: {

--- a/frontend/src/i18n/zh-hans/index.ts
+++ b/frontend/src/i18n/zh-hans/index.ts
@@ -1,11 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
-  const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
   const translation = {
     translation: {
       app: {
-        name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+        name: 'Bedrock Claude Chat',
+        nameWithoutClaude: 'Bedrock Chat',
         inputMessage: '请输入',
         starredBots: '我的 Bots 收藏',
         recentlyUsedBots: '最近使用过的 Bots',

--- a/frontend/src/i18n/zh-hans/index.ts
+++ b/frontend/src/i18n/zh-hans/index.ts
@@ -1,10 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
+  const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
   const translation = {
     translation: {
       app: {
-        name: 'Bedrock Claude Chat',
+        name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
         inputMessage: '请输入',
         starredBots: '我的 Bots 收藏',
         recentlyUsedBots: '最近使用过的 Bots',

--- a/frontend/src/i18n/zh-hant/index.ts
+++ b/frontend/src/i18n/zh-hant/index.ts
@@ -1,10 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
+  const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
   const translation = {
     translation: {
       app: {
-        name: 'Bedrock Claude Chat',
+        name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
         inputMessage: '請輸入訊息',
         starredBots: '我的最愛 Bots',
         recentlyUsedBots: '最近用過的 Bots',

--- a/frontend/src/i18n/zh-hant/index.ts
+++ b/frontend/src/i18n/zh-hant/index.ts
@@ -1,11 +1,11 @@
 // Check for any missing settings by uncomment
 // import en from '../en';
 // const translation: typeof en = {
-  const ENABLE_MISTRAL: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
   const translation = {
     translation: {
       app: {
-        name: !ENABLE_MISTRAL ? 'Bedrock Claude Chat' : 'Bedrock Chat',
+        name: 'Bedrock Claude Chat',
+        nameWithoutClaude: 'Bedrock Chat',
         inputMessage: '請輸入訊息',
         starredBots: '我的最愛 Bots',
         recentlyUsedBots: '最近用過的 Bots',

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -31,6 +31,7 @@ import useModel from '../hooks/useModel';
 const ChatPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
   const {
     postingMessage,
@@ -296,7 +297,7 @@ const ChatPage: React.FC = () => {
               <SwitchBedrockModel className="mt-3 w-min" />
             )}
             <div className="absolute mx-3 my-20 flex items-center justify-center text-4xl font-bold text-gray">
-              {t('app.name')}
+              {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
             </div>
           </div>
         ) : (

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -28,10 +28,11 @@ import Alert from '../components/Alert';
 import useBotSummary from '../hooks/useBotSummary';
 import useModel from '../hooks/useModel';
 
+const MISTRAL_ENABLED: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
+
 const ChatPage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const mistralEnabled: boolean = import.meta.env.VITE_APP_ENABLE_MISTRAL === 'true';
 
   const {
     postingMessage,
@@ -297,7 +298,7 @@ const ChatPage: React.FC = () => {
               <SwitchBedrockModel className="mt-3 w-min" />
             )}
             <div className="absolute mx-3 my-20 flex items-center justify-center text-4xl font-bold text-gray">
-              {!mistralEnabled ? t('app.name'):t('app.nameWithoutClaude')}
+              {!MISTRAL_ENABLED ? t('app.name') : t('app.nameWithoutClaude')}
             </div>
           </div>
         ) : (


### PR DESCRIPTION
 when toggling enableMistral, the app name from UI change to Bedrock Chat

also fixed display name of Mistral Large model

*Issue #, if available:*

*Description of changes:*
Before:
<img width="1011" alt="image" src="https://github.com/aws-samples/bedrock-claude-chat/assets/3147161/034a6256-5aa0-482d-adef-c7a66f316b5c">


After:
<img width="1022" alt="image" src="https://github.com/aws-samples/bedrock-claude-chat/assets/3147161/fceaf0b4-3261-46a9-9d78-c6bef68c1ce4">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
