### PR TITLE
fix: enable storageEncrypted option for vector store

### DIFF
--- a/cdk/lib/constructs/vectorstore.ts
+++ b/cdk/lib/constructs/vectorstore.ts
@@ -46,6 +46,7 @@ export class VectorStore extends Construct {
       securityGroups: [sg],
       defaultDatabaseName: DB_NAME,
       enableDataApi: true,
+      storageEncrypted: true,
       serverlessV2MinCapacity: 0.5,
       serverlessV2MaxCapacity: 5.0,
       writer: rds.ClusterInstance.serverlessV2("writer", {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
enable storageEncrypted for vector store

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
