### PR TITLE
feature: customize number of search results while chatting

### DIFF
--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -80,7 +80,7 @@ class ChatInput(BaseSchema):
     conversation_id: str
     message: MessageInput
     bot_id: str | None = Field(None)
-
+    search_size: int | None = Field(default=40, ge=1, le=100)
 
 class ChatInputWithToken(ChatInput):
     token: str

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -294,7 +294,7 @@ def chat(user_id: str, chat_input: ChatInput) -> ChatOutput:
         # NOTE: Currently embedding not support multi-modal. For now, use the last content.
         query = conversation.message_map[user_msg_id].content[-1].body
         search_results = search_related_docs(
-            bot_id=bot.id, limit=SEARCH_CONFIG["max_results"], query=query
+            bot_id=bot.id, limit=chat_input.search_size, query=query # Use chat_input.search_size
         )
         logger.info(f"Search results from vector store: {search_results}")
 

--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -83,7 +83,7 @@ def process_chat_input(
         # NOTE: Currently embedding not support multi-modal. For now, use the last text content.
         query = conversation.message_map[user_msg_id].content[-1].body
         search_results = search_related_docs(
-            bot_id=bot.id, limit=SEARCH_CONFIG["max_results"], query=query
+            bot_id=bot.id, limit=chat_input.search_size, query=query # Use chat_input.search_size
         )
         logger.info(f"Search results from vector store: {search_results}")
 

--- a/frontend/src/@types/conversation.d.ts
+++ b/frontend/src/@types/conversation.d.ts
@@ -41,6 +41,7 @@ export type PostMessageRequest = {
     parentMessageId: null | string;
   };
   botId?: string;
+  searchSize?: number;
 };
 
 export type PostMessageResponse = {

--- a/frontend/src/components/InputChatContent.tsx
+++ b/frontend/src/components/InputChatContent.tsx
@@ -20,6 +20,7 @@ import { create } from 'zustand';
 import ButtonFileChoose from './ButtonFileChoose';
 import { BaseProps } from '../@types/common';
 import ModalDialog from './ModalDialog';
+import Help from '../components/Help';
 
 type Props = BaseProps & {
   disabledSend?: boolean;
@@ -75,7 +76,7 @@ const useInputChatContentState = create<{
 
 const InputChatContent: React.FC<Props> = (props) => {
   const { t } = useTranslation();
-  const { postingMessage, hasError, messages } = useChat();
+  const { postingMessage, hasError, messages, searchSize, setSearchSize } = useChat();
   const { disabledImageUpload, model, acceptMediaType } = useModel();
 
   const [content, setContent] = useState('');
@@ -235,6 +236,21 @@ const InputChatContent: React.FC<Props> = (props) => {
 
   return (
     <>
+      <div className="absolute top-0 right-0 mt-4 mr-4 flex items-center">
+        <label className="mr-2">{t('SearchParams.searchSize.label')}</label>
+        <input
+          type="number"
+          value={searchSize}
+          onChange={(e) => setSearchSize(Number(e.target.value))}
+          className="border rounded px-2 py-1 w-20"
+          min={1}
+          max={100}
+        />
+        <Help
+          direction="left"
+          message={t('SearchParams.searchSize.help')}
+        />
+      </div>
       {props.dndMode && (
         <div
           className="fixed left-0 top-0 h-full w-full bg-black/40"

--- a/frontend/src/components/SearchSizeInput.tsx
+++ b/frontend/src/components/SearchSizeInput.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Help from './Help';
+import useChat from '../hooks/useChat';
+
+const SearchSizeInput: React.FC = () => {
+  const { t } = useTranslation();
+  const { searchSize, setSearchSize } = useChat();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (value <= 100) {
+      setSearchSize(value);
+    } else {
+      setSearchSize(100); // If value exceeds 100, set it to 100
+    }
+  };
+
+  return (
+    <div className="absolute top-0 right-0 mt-4 mr-4 flex items-center">
+      <label htmlFor="searchSizeInput" className="mr-2 text-sm font-semibold">{t('SearchParams.searchSize.label')}</label>
+      <input
+        id="searchSizeInput"
+        type="number"
+        value={searchSize}
+        onChange={handleChange}
+        className="p-1 border rounded-lg text-sm w-16"
+        min={1}
+        max={100}
+      />
+      <Help
+        direction="left"
+        message={t('SearchParams.searchSize.help')}
+      />
+    </div>
+  );
+};
+
+export default SearchSizeInput;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -17,3 +17,15 @@ export const EDGE_EMBEDDING_PARAMS = {
     STEP: 2,
   },
 };
+
+export const DEFAULT_SEARCH_CONFIG = {
+  searchSize: 40,
+};
+
+export const SEARCH_PARAMS_RANGE = {
+  searchSize: {
+    MIN: 1,
+    MAX: 100,
+    STEP: 1,
+  },
+};

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -21,6 +21,7 @@ import { convertMessageMapToArray } from '../utils/MessageUtils';
 import { useTranslation } from 'react-i18next';
 import useModel from './useModel';
 import useFeedbackApi from './useFeedbackApi';
+import {DEFAULT_SEARCH_CONFIG} from '../constants/index';
 
 type ChatStateType = {
   [id: string]: MessageMap;
@@ -72,6 +73,8 @@ const useChatState = create<{
   setIsGeneratedTitle: (b: boolean) => void;
   getPostedModel: () => Model;
   shouldUpdateMessages: (currentConversation: Conversation) => boolean;
+  searchSize: number;
+  setSearchSize: (size: number) => void;
 }>((set, get) => {
   return {
     conversationId: '',
@@ -81,6 +84,12 @@ const useChatState = create<{
           conversationId: s,
         };
       });
+    },
+    searchSize: DEFAULT_SEARCH_CONFIG.searchSize,
+    setSearchSize: (size: number) => {
+      set(() => ({
+        searchSize: size,
+      }));
     },
     postingMessage: false,
     setPostingMessage: (b) => {
@@ -241,6 +250,8 @@ const useChat = () => {
     setRelatedDocuments,
     moveRelatedDocuments,
     shouldUpdateMessages,
+    searchSize,
+    setSearchSize,
   } = useChatState();
   const { open: openSnackbar } = useSnackbar();
   const navigate = useNavigate();
@@ -379,6 +390,7 @@ const useChat = () => {
         parentMessageId: parentMessageId,
       },
       botId: bot?.botId,
+      searchSize,
     };
     const createNewConversation = () => {
       // Copy State to prevent screen flicker
@@ -506,6 +518,7 @@ const useChat = () => {
         parentMessageId: parentMessage.parent,
       },
       botId: props?.bot?.botId,
+      searchSize,
     };
 
     if (input.message.parentMessageId === null) {
@@ -629,6 +642,8 @@ const useChat = () => {
           mutate();
         });
     },
+    setSearchSize,
+    searchSize,
   };
 };
 

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -364,6 +364,13 @@ How would you categorize this email?`,
         invalidOriginFormat: 'Invalid Origin format.',
       },
     },
+    SearchParams: {
+      searchSize: {
+        label: 'Search Size',
+        hint: 'The number of results to return for each query',
+        help: 'Increasing the search size will return more results, but may also increase latency.',
+      },
+    },
     embeddingSettings: {
       title: 'Embedding Setting',
       description:

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -319,6 +319,13 @@ Las categorías de clasificación son:
         invalidOriginFormat: 'Formato de origen inválido.',
       },
     },
+    SearchParams: {
+      searchSize: {
+        label: 'Tamaño de Búsqueda',
+        hint: 'El número de resultados a devolver por cada consulta',
+        help: 'Aumentar el tamaño de búsqueda devolverá más resultados, pero también puede aumentar la latencia.',
+      },
+    },    
     embeddingSettings: {
       title: 'Configuración de Incrustación',
       description: 'Puedes configurar los parámetros para las incrustaciones vectoriales. Al ajustar los parámetros, puedes cambiar la precisión de la recuperación de documentos.',

--- a/frontend/src/i18n/it/index.ts
+++ b/frontend/src/i18n/it/index.ts
@@ -342,6 +342,13 @@ Come classificheresti questa email?`,
         invalidOriginFormat: 'Formato di origine non valido.',
       },
     },
+    SearchParams: {
+      searchSize: {
+        label: 'Dimensione di Ricerca',
+        hint: 'Il numero di risultati da restituire per ogni query',
+        help: 'Aumentare la dimensione della ricerca restituirà più risultati, ma può anche aumentare la latenza.',
+      },
+    },    
     embeddingSettings: {
       title: 'Impostazione di incorporamento',
       description:

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -368,6 +368,13 @@ const translation = {
         invalidOriginFormat: 'オリジンのフォーマットが異なります。',
       },
     },
+    SearchParams: {
+      searchSize: {
+        label: '検索サイズ',
+        hint: 'クエリごとに返す結果の数',
+        help: '検索サイズを増やすと、より多くの結果が返されますが、待ち時間が増える場合もあります。',
+      },
+    },   
     embeddingSettings: {
       title: 'ベクトル埋め込みパラメーター設定',
       description:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/bedrock-claude-chat/issues/313

*Description of changes:*
Adding an input box next to the chatbox to allow a user to customize the Search Size (max 100) (equivalent to earlier max_results). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
