### PR TITLE
BUG: fixed bash.sh syntax error

### DIFF
--- a/bin.sh
+++ b/bin.sh
@@ -35,10 +35,6 @@ echo "Please enter y or n."
 esac
 done
 
-
-StackName="CodeBuildForDeploy"
-stackId=$(aws cloudformation create-stack 
-
 # Default parameters
 ALLOW_SELF_REGISTER="true"
 IPV4_RANGES=""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running the bin.sh, the following error occurred, so I removed the relevant section. The CloudFormation deployment is executed using `aws cloudformation deploy` command, and the StackName is declared on another line, making this entry unnecessary.

```
./bin.sh: line 135: unexpected EOF while looking for matching `)'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
