### PR TITLE
Fix publish API error

### DIFF
--- a/cdk/bin/api-publish.ts
+++ b/cdk/bin/api-publish.ts
@@ -3,7 +3,6 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ApiPublishmentStack, VpcConfig } from "../lib/api-publishment-stack";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
-import { DbConfig } from "../lib/constructs/embedding";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 
 const app = new cdk.App();

--- a/cdk/lib/api-publishment-stack.ts
+++ b/cdk/lib/api-publishment-stack.ts
@@ -147,6 +147,7 @@ export class ApiPublishmentStack extends Stack {
         role: handlerRole,
       }
     );
+    dbSecret.grantRead(sqsConsumeHandler);
     sqsConsumeHandler.addEventSource(
       new lambdaEventSources.SqsEventSource(chatQueue)
     );


### PR DESCRIPTION
*Issue #, if available:*
#352 (also fix #344)

*Description of changes:*
Fix the leftover `DbConfig` import which is removed from [cdk/lib/constructs/embedding.ts](https://github.com/aws-samples/bedrock-claude-chat/commit/a3453b42682cb2f247ba7f06b2ed108e965d60ad#diff-03c0e9b3edbe8bf16f44e1e3bbc077b1c44f1bdb956223db1bdcfa2b365ceb8b) during previous refactor (a3453b42682cb2f247ba7f06b2ed108e965d60ad), in order to fix publish api not working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
