### PR TITLE
Feature: Conversation Quick Starter

### DIFF
--- a/backend/app/agents/agent.py
+++ b/backend/app/agents/agent.py
@@ -217,7 +217,10 @@ class RunnableAgent(BaseSingleActionAgent):
         intermediate_steps: list[tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[AgentAction, AgentFinish,]:
+    ) -> Union[
+        AgentAction,
+        AgentFinish,
+    ]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -330,9 +333,9 @@ class AgentExecutor(Chain):
     `"generate"` calls the agent's LLM Chain one final time to generate
         a final answer based on the previous steps.
     """
-    handle_parsing_errors: Union[
-        bool, str, Callable[[OutputParserException], str]
-    ] = False
+    handle_parsing_errors: Union[bool, str, Callable[[OutputParserException], str]] = (
+        False
+    )
     """How to handle errors raised by the agent's output parser.
     Defaults to `False`, which raises the error.
     If `true`, the error will be sent back to the LLM as an observation.

--- a/backend/app/agents/agent.py
+++ b/backend/app/agents/agent.py
@@ -217,10 +217,7 @@ class RunnableAgent(BaseSingleActionAgent):
         intermediate_steps: list[tuple[AgentAction, str]],
         callbacks: Callbacks = None,
         **kwargs: Any,
-    ) -> Union[
-        AgentAction,
-        AgentFinish,
-    ]:
+    ) -> Union[AgentAction, AgentFinish,]:
         """Based on past history and current inputs, decide what to do.
 
         Args:
@@ -333,9 +330,9 @@ class AgentExecutor(Chain):
     `"generate"` calls the agent's LLM Chain one final time to generate
         a final answer based on the previous steps.
     """
-    handle_parsing_errors: Union[bool, str, Callable[[OutputParserException], str]] = (
-        False
-    )
+    handle_parsing_errors: Union[
+        bool, str, Callable[[OutputParserException], str]
+    ] = False
     """How to handle errors raised by the agent's output parser.
     Defaults to `False`, which raises the error.
     If `true`, the error will be sent back to the LLM as an observation.

--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -163,6 +163,7 @@ def store_alias(user_id: str, alias: BotAliasModel):
         "IsPinned": alias.is_pinned,
         "SyncStatus": alias.sync_status,
         "HasKnowledge": alias.has_knowledge,
+        "HasAgent": alias.has_agent,
         "ConversationQuickStarters": [
             starter.model_dump() for starter in alias.conversation_quick_starters
         ],
@@ -518,7 +519,8 @@ def find_alias_by_id(user_id: str, alias_id: str) -> BotAliasModel:
         is_pinned=item["IsPinned"],
         sync_status=item["SyncStatus"],
         has_knowledge=item["HasKnowledge"],
-        conversation_quick_starters=item["ConversationQuickStarters"],
+        has_agent=item.get("HasAgent", False),
+        conversation_quick_starters=item.get("ConversationQuickStarters", []),
     )
 
     logger.info(f"Found alias: {bot}")

--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -74,7 +74,9 @@ def store_bot(user_id: str, custom_bot: BotModel):
         "ApiPublishedDatetime": custom_bot.published_api_datetime,
         "ApiPublishCodeBuildId": custom_bot.published_api_codebuild_id,
         "DisplayRetrievedChunks": custom_bot.display_retrieved_chunks,
-        "ConversationQuickStarters": custom_bot.conversation_quick_starters,
+        "ConversationQuickStarters": [
+            starter.model_dump() for starter in custom_bot.conversation_quick_starters
+        ],
     }
 
     response = table.put_item(Item=item)
@@ -161,7 +163,9 @@ def store_alias(user_id: str, alias: BotAliasModel):
         "IsPinned": alias.is_pinned,
         "SyncStatus": alias.sync_status,
         "HasKnowledge": alias.has_knowledge,
-        "ConversationQuickStarters": alias.conversation_quick_starters,
+        "ConversationQuickStarters": [
+            starter.model_dump() for starter in alias.conversation_quick_starters
+        ],
     }
 
     response = table.put_item(Item=item)

--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -95,7 +95,7 @@ def update_bot(
     sync_status: type_sync_status,
     sync_status_reason: str,
     display_retrieved_chunks: bool,
-    conversation_quick_starters: list[ConversationQuickStarterModel]
+    conversation_quick_starters: list[ConversationQuickStarterModel],
 ):
     """Update bot title, description, and instruction.
     NOTE: Use `update_bot_visibility` to update visibility.
@@ -161,7 +161,7 @@ def store_alias(user_id: str, alias: BotAliasModel):
         "IsPinned": alias.is_pinned,
         "SyncStatus": alias.sync_status,
         "HasKnowledge": alias.has_knowledge,
-        "ConversationQuickStarters": alias.conversation_quick_starters
+        "ConversationQuickStarters": alias.conversation_quick_starters,
     }
 
     response = table.put_item(Item=item)

--- a/backend/app/repositories/models/custom_bot.py
+++ b/backend/app/repositories/models/custom_bot.py
@@ -103,6 +103,7 @@ class BotAliasModel(BaseModel):
     is_pinned: bool
     sync_status: type_sync_status
     has_knowledge: bool
+    has_agent: bool
     conversation_quick_starters: list[ConversationQuickStarterModel]
 
 

--- a/backend/app/repositories/models/custom_bot.py
+++ b/backend/app/repositories/models/custom_bot.py
@@ -51,6 +51,9 @@ class AgentToolModel(BaseModel):
 class AgentModel(BaseModel):
     tools: list[AgentToolModel]
 
+class ConversationQuickStarterModel(BaseModel):
+    title: str
+    example: str
 
 class BotModel(BaseModel):
     id: str
@@ -75,6 +78,7 @@ class BotModel(BaseModel):
     published_api_datetime: int | None
     published_api_codebuild_id: str | None
     display_retrieved_chunks: bool
+    conversation_quick_starters: list[ConversationQuickStarterModel]
 
     def has_knowledge(self) -> bool:
         return (
@@ -97,6 +101,7 @@ class BotAliasModel(BaseModel):
     is_pinned: bool
     sync_status: type_sync_status
     has_knowledge: bool
+    conversation_quick_starters: list[ConversationQuickStarterModel]
 
 
 class BotMeta(BaseModel):

--- a/backend/app/repositories/models/custom_bot.py
+++ b/backend/app/repositories/models/custom_bot.py
@@ -51,9 +51,11 @@ class AgentToolModel(BaseModel):
 class AgentModel(BaseModel):
     tools: list[AgentToolModel]
 
+
 class ConversationQuickStarterModel(BaseModel):
     title: str
     example: str
+
 
 class BotModel(BaseModel):
     id: str

--- a/backend/app/routes/bot.py
+++ b/backend/app/routes/bot.py
@@ -169,7 +169,8 @@ def get_private_bot(request: Request, bot_id: str):
             ConversationQuickStarter(
                 title=starter.title,
                 example=starter.example,
-            ) for starter in bot.conversation_quick_starters
+            )
+            for starter in bot.conversation_quick_starters
         ],
     )
     return output

--- a/backend/app/routes/bot.py
+++ b/backend/app/routes/bot.py
@@ -21,6 +21,7 @@ from app.routes.schemas.bot import (
     GenerationParams,
     Knowledge,
     SearchParams,
+    ConversationQuickStarter,
 )
 from app.usecases.bot import (
     create_new_bot,
@@ -164,6 +165,12 @@ def get_private_bot(request: Request, bot_id: str):
         sync_status_reason=bot.sync_status_reason,
         sync_last_exec_id=bot.sync_last_exec_id,
         display_retrieved_chunks=bot.display_retrieved_chunks,
+        conversation_quick_starters=[
+            ConversationQuickStarter(
+                title=starter.title,
+                example=starter.example,
+            ) for starter in bot.conversation_quick_starters
+        ],
     )
     return output
 

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -60,9 +60,11 @@ class KnowledgeDiffInput(BaseSchema):
     deleted_filenames: list[str]
     unchanged_filenames: list[str]
 
+
 class ConversationQuickStarter(BaseSchema):
     title: str
     example: str
+
 
 class BotInput(BaseSchema):
     id: str
@@ -76,6 +78,7 @@ class BotInput(BaseSchema):
     knowledge: Knowledge | None
     display_retrieved_chunks: bool
     conversation_quick_starters: list[ConversationQuickStarter] | None
+
 
 class BotModifyInput(BaseSchema):
     title: str

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -60,6 +60,9 @@ class KnowledgeDiffInput(BaseSchema):
     deleted_filenames: list[str]
     unchanged_filenames: list[str]
 
+class ConversationQuickStarter(BaseSchema):
+    title: str
+    example: str
 
 class BotInput(BaseSchema):
     id: str
@@ -72,7 +75,7 @@ class BotInput(BaseSchema):
     agent: Optional[AgentInput] = None
     knowledge: Knowledge | None
     display_retrieved_chunks: bool
-
+    conversation_quick_starters: list[ConversationQuickStarter] | None
 
 class BotModifyInput(BaseSchema):
     title: str
@@ -84,6 +87,7 @@ class BotModifyInput(BaseSchema):
     agent: Optional[AgentInput] = None
     knowledge: KnowledgeDiffInput | None
     display_retrieved_chunks: bool
+    conversation_quick_starters: list[ConversationQuickStarter] | None
 
     def has_update_files(self) -> bool:
         return self.knowledge is not None and (
@@ -134,6 +138,7 @@ class BotModifyOutput(BaseSchema):
     search_params: SearchParams
     agent: Agent
     knowledge: Knowledge
+    conversation_quick_starters: list[ConversationQuickStarter]
 
 
 class BotOutput(BaseSchema):
@@ -156,6 +161,7 @@ class BotOutput(BaseSchema):
     sync_status_reason: str
     sync_last_exec_id: str
     display_retrieved_chunks: bool
+    conversation_quick_starters: list[ConversationQuickStarter]
 
 
 class BotMetaOutput(BaseSchema):
@@ -185,6 +191,7 @@ class BotSummaryOutput(BaseSchema):
     owned: bool
     sync_status: type_sync_status
     has_knowledge: bool
+    conversation_quick_starters: list[ConversationQuickStarter]
 
 
 class BotSwitchVisibilityInput(BaseSchema):

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -580,13 +580,13 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             has_knowledge=alias.has_knowledge,
             conversation_quick_starters=(
                 []
-                if bot.conversation_quick_starters is None
+                if alias.conversation_quick_starters is None
                 else [
                     ConversationQuickStarter(
                         title=starter.title,
                         example=starter.example,
                     )
-                    for starter in bot.conversation_quick_starters
+                    for starter in alias.conversation_quick_starters
                 ]
             ),
         )

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -35,6 +35,7 @@ from app.repositories.models.custom_bot import (
     GenerationParamsModel,
     KnowledgeModel,
     SearchParamsModel,
+    ConversationQuickStarterModel,
 )
 from app.routes.schemas.bot import (
     Agent,
@@ -49,6 +50,7 @@ from app.routes.schemas.bot import (
     Knowledge,
     SearchParams,
     type_sync_status,
+    ConversationQuickStarter,
 )
 from app.utils import (
     compose_upload_document_s3_path,
@@ -193,6 +195,12 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
             published_api_datetime=None,
             published_api_codebuild_id=None,
             display_retrieved_chunks=bot_input.display_retrieved_chunks,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(
+                    title=starter.title,
+                    example=starter.example,
+                ) for starter in bot_input.conversation_quick_starters
+            ],
         ),
     )
     return BotOutput(
@@ -225,6 +233,7 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
         sync_status_reason="",
         sync_last_exec_id="",
         display_retrieved_chunks=bot_input.display_retrieved_chunks,
+        conversation_quick_starters=bot_input.conversation_quick_starters,
     )
 
 
@@ -330,6 +339,7 @@ def modify_owned_bot(
         sync_status=sync_status,
         sync_status_reason="",
         display_retrieved_chunks=modify_input.display_retrieved_chunks,
+        conversation_quick_starters=modify_input.conversation_quick_starters,
     )
 
     return BotModifyOutput(
@@ -355,6 +365,7 @@ def modify_owned_bot(
             sitemap_urls=sitemap_urls,
             filenames=filenames,
         ),
+        conversation_quick_starters=modify_input.conversation_quick_starters,
     )
 
 
@@ -449,6 +460,7 @@ def fetch_all_bots_by_user_id(
                 or bot.description != item["Description"]
                 or bot.sync_status != item["SyncStatus"]
                 or bot.has_knowledge() != item["HasKnowledge"]
+                or bot.conversation_quick_starters != item["ConversationQuickStarters"]
             ):
                 # Update alias to the latest original bot
                 store_alias(
@@ -464,6 +476,7 @@ def fetch_all_bots_by_user_id(
                         is_pinned=item["IsPinned"],
                         sync_status=bot.sync_status,
                         has_knowledge=bot.has_knowledge(),
+                        conversation_quick_starters=item["ConversationQuickStarters"],
                     ),
                 )
 
@@ -503,6 +516,12 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             owned=True,
             sync_status=bot.sync_status,
             has_knowledge=bot.has_knowledge(),
+            conversation_quick_starters=[
+                ConversationQuickStarter(
+                    title=starter.title,
+                    example=starter.example,
+                ) for starter in bot.conversation_quick_starters
+            ],
         )
 
     except RecordNotFoundError:
@@ -522,6 +541,12 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             owned=False,
             sync_status=alias.sync_status,
             has_knowledge=alias.has_knowledge,
+            conversation_quick_starters=[
+                ConversationQuickStarter(
+                    title=starter.title,
+                    example=starter.example,
+                ) for starter in bot.conversation_quick_starters
+            ],
         )
     except RecordNotFoundError:
         pass
@@ -543,6 +568,12 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 is_pinned=False,
                 sync_status=bot.sync_status,
                 has_knowledge=bot.has_knowledge(),
+                conversation_quick_starters=[
+                    ConversationQuickStarter(
+                        title=starter.title,
+                        example=starter.example,
+                    ) for starter in bot.conversation_quick_starters
+                ],
             ),
         )
         return BotSummaryOutput(
@@ -557,6 +588,12 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             owned=False,
             sync_status=bot.sync_status,
             has_knowledge=bot.has_knowledge(),
+            conversation_quick_starters=[
+                ConversationQuickStarter(
+                    title=starter.title,
+                    example=starter.example,
+                ) for starter in bot.conversation_quick_starters
+            ],
         )
     except RecordNotFoundError:
         raise RecordNotFoundError(

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -511,6 +511,7 @@ def fetch_all_bots_by_user_id(
                         is_pinned=item["IsPinned"],
                         sync_status=bot.sync_status,
                         has_knowledge=bot.has_knowledge(),
+                        has_agent=bot.is_agent_enabled(),
                         conversation_quick_starters=item["ConversationQuickStarters"],
                     ),
                 )
@@ -573,7 +574,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             last_used_time=alias.last_used_time,
             is_pinned=alias.is_pinned,
             is_public=True,
-            has_agent=bot.is_agent_enabled(),
+            has_agent=alias.has_agent,
             owned=False,
             sync_status=alias.sync_status,
             has_knowledge=alias.has_knowledge,
@@ -609,6 +610,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 is_pinned=False,
                 sync_status=bot.sync_status,
                 has_knowledge=bot.has_knowledge(),
+                has_agent=bot.is_agent_enabled(),
                 conversation_quick_starters=[
                     ConversationQuickStarterModel(
                         title=starter.title,

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -195,12 +195,17 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
             published_api_datetime=None,
             published_api_codebuild_id=None,
             display_retrieved_chunks=bot_input.display_retrieved_chunks,
-            conversation_quick_starters=[
-                ConversationQuickStarterModel(
-                    title=starter.title,
-                    example=starter.example,
-                ) for starter in bot_input.conversation_quick_starters
-            ],
+            conversation_quick_starters=(
+                []
+                if bot_input.conversation_quick_starters is None
+                else [
+                    ConversationQuickStarterModel(
+                        title=starter.title,
+                        example=starter.example,
+                    )
+                    for starter in bot_input.conversation_quick_starters
+                ]
+            ),
         ),
     )
     return BotOutput(
@@ -233,7 +238,17 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
         sync_status_reason="",
         sync_last_exec_id="",
         display_retrieved_chunks=bot_input.display_retrieved_chunks,
-        conversation_quick_starters=bot_input.conversation_quick_starters,
+        conversation_quick_starters=(
+            []
+            if bot_input.conversation_quick_starters is None
+            else [
+                ConversationQuickStarter(
+                    title=starter.title,
+                    example=starter.example,
+                )
+                for starter in bot_input.conversation_quick_starters
+            ]
+        ),
     )
 
 
@@ -339,7 +354,17 @@ def modify_owned_bot(
         sync_status=sync_status,
         sync_status_reason="",
         display_retrieved_chunks=modify_input.display_retrieved_chunks,
-        conversation_quick_starters=modify_input.conversation_quick_starters,
+        conversation_quick_starters=(
+            []
+            if modify_input.conversation_quick_starters is None
+            else [
+                ConversationQuickStarterModel(
+                    title=starter.title,
+                    example=starter.example,
+                )
+                for starter in modify_input.conversation_quick_starters
+            ]
+        ),
     )
 
     return BotModifyOutput(
@@ -365,7 +390,17 @@ def modify_owned_bot(
             sitemap_urls=sitemap_urls,
             filenames=filenames,
         ),
-        conversation_quick_starters=modify_input.conversation_quick_starters,
+        conversation_quick_starters=(
+            []
+            if modify_input.conversation_quick_starters is None
+            else [
+                ConversationQuickStarter(
+                    title=starter.title,
+                    example=starter.example,
+                )
+                for starter in modify_input.conversation_quick_starters
+            ]
+        ),
     )
 
 
@@ -520,7 +555,8 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 ConversationQuickStarter(
                     title=starter.title,
                     example=starter.example,
-                ) for starter in bot.conversation_quick_starters
+                )
+                for starter in bot.conversation_quick_starters
             ],
         )
 
@@ -541,12 +577,17 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
             owned=False,
             sync_status=alias.sync_status,
             has_knowledge=alias.has_knowledge,
-            conversation_quick_starters=[
-                ConversationQuickStarter(
-                    title=starter.title,
-                    example=starter.example,
-                ) for starter in bot.conversation_quick_starters
-            ],
+            conversation_quick_starters=(
+                []
+                if bot.conversation_quick_starters is None
+                else [
+                    ConversationQuickStarter(
+                        title=starter.title,
+                        example=starter.example,
+                    )
+                    for starter in bot.conversation_quick_starters
+                ]
+            ),
         )
     except RecordNotFoundError:
         pass
@@ -569,10 +610,11 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 sync_status=bot.sync_status,
                 has_knowledge=bot.has_knowledge(),
                 conversation_quick_starters=[
-                    ConversationQuickStarter(
+                    ConversationQuickStarterModel(
                         title=starter.title,
                         example=starter.example,
-                    ) for starter in bot.conversation_quick_starters
+                    )
+                    for starter in bot.conversation_quick_starters
                 ],
             ),
         )
@@ -592,7 +634,8 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 ConversationQuickStarter(
                     title=starter.title,
                     example=starter.example,
-                ) for starter in bot.conversation_quick_starters
+                )
+                for starter in bot.conversation_quick_starters
             ],
         )
     except RecordNotFoundError:

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -24,7 +24,11 @@ from app.repositories.models.conversation import (
     ConversationModel,
     MessageModel,
 )
-from app.repositories.models.custom_bot import BotAliasModel, BotModel
+from app.repositories.models.custom_bot import (
+    BotAliasModel,
+    BotModel,
+    ConversationQuickStarterModel,
+)
 from app.routes.schemas.conversation import (
     ChatInput,
     ChatOutput,
@@ -149,6 +153,17 @@ def prepare_conversation(
                             is_pinned=False,
                             sync_status=bot.sync_status,
                             has_knowledge=bot.has_knowledge(),
+                            conversation_quick_starters=(
+                                []
+                                if bot.conversation_quick_starters is None
+                                else [
+                                    ConversationQuickStarterModel(
+                                        title=starter.title,
+                                        example=starter.example,
+                                    )
+                                    for starter in bot.conversation_quick_starters
+                                ]
+                            ),
                         ),
                     )
 

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -153,6 +153,7 @@ def prepare_conversation(
                             is_pinned=False,
                             sync_status=bot.sync_status,
                             has_knowledge=bot.has_knowledge(),
+                            has_agent=bot.is_agent_enabled(),
                             conversation_quick_starters=(
                                 []
                                 if bot.conversation_quick_starters is None

--- a/backend/tests/test_repositories/test_conversation.py
+++ b/backend/tests/test_repositories/test_conversation.py
@@ -31,6 +31,7 @@ from app.repositories.models.custom_bot import (
     GenerationParamsModel,
     KnowledgeModel,
     SearchParamsModel,
+    ConversationQuickStarterModel,
 )
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
@@ -408,6 +409,9 @@ class TestConversationBotRepository(unittest.TestCase):
             published_api_datetime=0,
             published_api_stack_name="",
             display_retrieved_chunks=True,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(title="QS title", example="QS example")
+            ],
         )
         bot2 = BotModel(
             id="2",
@@ -452,6 +456,9 @@ class TestConversationBotRepository(unittest.TestCase):
             published_api_datetime=0,
             published_api_stack_name="",
             display_retrieved_chunks=True,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(title="QS title", example="QS example")
+            ],
         )
 
         store_conversation("user", conversation1)

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -225,6 +225,7 @@ class TestFindAllBots(unittest.IsolatedAsyncioTestCase):
             is_pinned=True,
             sync_status="RUNNING",
             has_knowledge=True,
+            has_agent=True,
             conversation_quick_starters=[
                 ConversationQuickStarterModel(title="QS title", example="QS example")
             ],
@@ -240,6 +241,7 @@ class TestFindAllBots(unittest.IsolatedAsyncioTestCase):
             is_pinned=False,
             sync_status="RUNNING",
             has_knowledge=True,
+            has_agent=True,
             conversation_quick_starters=[
                 ConversationQuickStarterModel(title="QS title", example="QS example")
             ],
@@ -306,6 +308,7 @@ class TestUpdateBotVisibility(unittest.TestCase):
             is_pinned=True,
             sync_status="RUNNING",
             has_knowledge=True,
+            has_agent=True,
             conversation_quick_starters=[
                 ConversationQuickStarterModel(title="QS title", example="QS example")
             ],

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -29,6 +29,7 @@ from app.repositories.models.custom_bot import (
     GenerationParamsModel,
     KnowledgeModel,
     SearchParamsModel,
+    ConversationQuickStarterModel,
 )
 from app.usecases.bot import fetch_all_bots_by_user_id
 from tests.test_repositories.utils.bot_factory import (
@@ -224,6 +225,9 @@ class TestFindAllBots(unittest.IsolatedAsyncioTestCase):
             is_pinned=True,
             sync_status="RUNNING",
             has_knowledge=True,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(title="QS title", example="QS example")
+            ],
         )
         alias2 = BotAliasModel(
             id="alias2",
@@ -236,6 +240,9 @@ class TestFindAllBots(unittest.IsolatedAsyncioTestCase):
             is_pinned=False,
             sync_status="RUNNING",
             has_knowledge=True,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(title="QS title", example="QS example")
+            ],
         )
         store_bot("user1", bot1)
         store_bot("user1", bot2)
@@ -299,6 +306,9 @@ class TestUpdateBotVisibility(unittest.TestCase):
             is_pinned=True,
             sync_status="RUNNING",
             has_knowledge=True,
+            conversation_quick_starters=[
+                ConversationQuickStarterModel(title="QS title", example="QS example")
+            ],
         )
         store_bot("user1", bot1)
         store_bot("user1", bot2)

--- a/backend/tests/test_repositories/utils/bot_factory.py
+++ b/backend/tests/test_repositories/utils/bot_factory.py
@@ -13,6 +13,7 @@ from app.repositories.models.custom_bot import (
     GenerationParamsModel,
     KnowledgeModel,
     SearchParamsModel,
+    ConversationQuickStarterModel,
 )
 from app.routes.schemas.bot import type_sync_status
 
@@ -27,6 +28,7 @@ def create_test_private_bot(
     published_api_datetime: int | None = None,
     published_api_codebuild_id: str | None = None,
     display_retrieved_chunks: bool = True,
+    conversation_quick_starters: list[ConversationQuickStarterModel] | None = None,
 ):
     return BotModel(
         id=id,
@@ -71,6 +73,9 @@ def create_test_private_bot(
         published_api_datetime=published_api_datetime,
         published_api_codebuild_id=published_api_codebuild_id,
         display_retrieved_chunks=display_retrieved_chunks,
+        conversation_quick_starters=(
+            [] if conversation_quick_starters is None else conversation_quick_starters
+        ),
     )
 
 

--- a/cdk/lib/constructs/frontend.ts
+++ b/cdk/lib/constructs/frontend.ts
@@ -138,7 +138,18 @@ export class Frontend extends Construct {
       assets: [
         {
           path: "../frontend",
-          exclude: ["node_modules", "dist"],
+          exclude: [
+            "node_modules",
+            "dist",
+            "dev-dist",
+            ".env",
+            ".env.local",
+            "../cdk/**/*",
+            "../backend/**/*",
+            "../example/**/*",
+            "../docs/**/*",
+            "../.github/**/*",
+          ],
           commands: ["npm ci"],
         },
       ],

--- a/frontend/src/@types/bot.d.ts
+++ b/frontend/src/@types/bot.d.ts
@@ -19,6 +19,11 @@ export type BotKnowledge = {
   filenames: string[];
 };
 
+export type ConversationQuickStarter = {
+  title: string;
+  example: string;
+};
+
 export type EmdeddingParams = {
   chunkSize: number;
   chunkOverlap: number;
@@ -61,11 +66,13 @@ export type BotDetails = BotMeta & {
   knowledge: BotKnowledge;
   syncStatusReason: string;
   displayRetrievedChunks: boolean;
+  conversationQuickStarters: ConversationQuickStarter[];
 };
 
 export type BotSummary = BotMeta & {
   hasKnowledge: boolean;
   hasAgent: boolean;
+  conversationQuickStarters: ConversationQuickStarter[];
 };
 
 export type BotFile = {
@@ -86,6 +93,7 @@ export type RegisterBotRequest = {
   searchParams?: SearchParams;
   knowledge?: BotKnowledge;
   displayRetrievedChunks: boolean;
+  conversationQuickStarters: ConversationQuickStarter[];
 };
 
 export type RegisterBotResponse = BotDetails;
@@ -100,6 +108,7 @@ export type UpdateBotRequest = {
   searchParams?: SearchParams;
   knowledge?: BotKnowledgeDiff;
   displayRetrievedChunks: boolean;
+  conversationQuickStarters: ConversationQuickStarter[];
 };
 
 export type UpdateBotResponse = {
@@ -112,6 +121,7 @@ export type UpdateBotResponse = {
   searchParams: SearchParams;
   knowledge?: BotKnowledge;
   displayRetrievedChunks: boolean;
+  conversationQuickStarters: ConversationQuickStarter[];
 };
 
 export type UpdateBotPinnedRequest = {

--- a/frontend/src/components/InputText.tsx
+++ b/frontend/src/components/InputText.tsx
@@ -7,6 +7,7 @@ type Props = {
   type?: HTMLInputTypeAttribute;
   value: string;
   disabled?: boolean;
+  placeholder?: string;
   hint?: string;
   errorMessage?: string;
   onChange?: (s: string) => void;
@@ -25,6 +26,7 @@ const InputText: React.FC<Props> = (props) => {
         )}
         disabled={props.disabled}
         value={props.value}
+        placeholder={props.placeholder}
         onChange={(e) => {
           props.onChange ? props.onChange(e.target.value) : null;
         }}

--- a/frontend/src/components/Textarea.tsx
+++ b/frontend/src/components/Textarea.tsx
@@ -42,7 +42,7 @@ const Textarea: React.FC<Props> = (props) => {
         className={twMerge(
           'peer w-full resize-none rounded p-1.5 outline-none',
           isMax ? 'overflow-y-auto' : 'overflow-hidden',
-          props.noBorder ? '' : 'border border-black/30',
+          props.noBorder ? '' : 'border border-aws-font-color/50',
           props.className
         )}
         rows={props.rows ?? 1}

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -86,6 +86,11 @@ const translation = {
           uploaded: 'Uploaded',
           error: 'ERROR',
         },
+        quickStarter: {
+          title: 'Conversation Quick Starter ',
+          exampleTitle: 'Title',
+          example: 'Conversation Example',
+        },
         citeRetrievedContexts: 'Retrieved Context Citation',
       },
       titleSubmenu: {
@@ -107,6 +112,10 @@ const translation = {
           file: 'The uploaded files will be used as Knowledge.',
           citeRetrievedContexts:
             'Configure whether to display context retrieved to answer user queries as citation information.\nIf enabled, users can access the original source URLs or files.',
+        },
+        quickStarter: {
+          overview:
+            'When starting a conversation, provide examples. Examples illustrate how to use the bot.',
         },
       },
       alert: {
@@ -497,6 +506,9 @@ How would you categorize this email?`,
       },
       chunkOverlapLessThanChunkSize: {
         message: 'Chunk overlap must be set to less than Chunk size',
+      },
+      quickStarter: {
+        message: 'Please input both Title and Conversation Example.',
       },
     },
   },

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -89,6 +89,11 @@ const translation = {
           uploaded: 'アップロード完了',
           error: 'エラー',
         },
+        quickStarter: {
+          title: '会話のクイックスタート',
+          exampleTitle: 'タイトル',
+          example: '会話例',
+        },
         citeRetrievedContexts: '取得したコンテキストの引用',
       },
       titleSubmenu: {
@@ -110,6 +115,10 @@ const translation = {
           file: 'アップロードしたファイルがナレッジとして利用されます。',
           citeRetrievedContexts:
             'ユーザーの質問に答えるために取得したコンテキストを引用情報として表示するかどうかを設定します。\n有効にすると、ユーザーは元のソースURLやファイルにアクセスできます。',
+        },
+        quickStarter: {
+          overview:
+            '会話を開始する際に、会話例を表示します。会話例を提供することで、ボットの使い方を利用者に示すことができます。',
         },
       },
       alert: {
@@ -501,6 +510,9 @@ const translation = {
       chunkOverlapLessThanChunkSize: {
         message:
           'チャンクオーバーラップはチャンクサイズより小さく設定する必要があります',
+      },
+      quickStarter: {
+        message: 'タイトルと入力例は、どちらも入力してください。',
       },
     },
   },

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   PiArrowsCounterClockwise,
   PiLink,
+  PiPenNib,
   PiPencilLine,
   PiStar,
   PiStarFill,
@@ -365,6 +366,24 @@ const ChatPage: React.FC = () => {
             </Alert>
           </div>
         )}
+        {messages.length === 0 && (
+          <div className="mb-3 flex w-11/12 flex-wrap-reverse justify-start gap-2 md:w-10/12 lg:w-4/6 xl:w-3/6">
+            {bot?.conversationQuickStarters.map((qs, idx) => (
+              <div
+                key={idx}
+                className="w-[calc(33.333%-0.5rem)] cursor-pointer rounded-2xl border border-aws-squid-ink/20 bg-white p-2  text-sm text-dark-gray  hover:shadow-lg hover:shadow-gray"
+                onClick={() => {
+                  onSend(qs.example);
+                }}>
+                <div>
+                  <PiPenNib />
+                </div>
+                {qs.title}
+              </div>
+            ))}
+          </div>
+        )}
+
         {bot?.hasAgent ? (
           <TextInputChatContent
             dndMode={dndMode}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It is a feature that allows you to set a Conversation Quick Starter for each bot.
By showing conversation examples with the Conversation Quick Starter, you can demonstrate to users how to use the bot.

<img width="696" alt="image" src="https://github.com/aws-samples/bedrock-claude-chat/assets/52243855/7de6ad47-8b76-42c2-83e5-42e842f6a892">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
