### PR TITLE
Feat/continue generate

### DIFF
--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -48,6 +48,7 @@ def store_conversation(
         # Ref: https://stackoverflow.com/questions/63026648/errormessage-class-decimal-inexact-class-decimal-rounded-while
         "TotalPrice": decimal(str(conversation.total_price)),
         "LastMessageId": conversation.last_message_id,
+        "ShouldContinue": conversation.should_continue,
     }
 
     if conversation.bot_id:
@@ -236,6 +237,7 @@ def find_conversation_by_id(user_id: str, conversation_id: str) -> ConversationM
         },
         last_message_id=item["LastMessageId"],
         bot_id=item["BotId"] if "BotId" in item else None,
+        should_continue=item.get("ShouldContinue", False),
     )
     logger.info(f"Found conversation: {conv}")
     return conv

--- a/backend/app/repositories/models/conversation.py
+++ b/backend/app/repositories/models/conversation.py
@@ -43,6 +43,7 @@ class ConversationModel(BaseModel):
     message_map: dict[str, MessageModel]
     last_message_id: str
     bot_id: str | None
+    should_continue: bool
 
 
 class ConversationMeta(BaseModel):

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -112,6 +112,7 @@ class Conversation(BaseSchema):
     message_map: dict[str, MessageOutput]
     last_message_id: str
     bot_id: str | None
+    should_continue: bool
 
 
 class NewTitleInput(BaseSchema):

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -170,8 +170,7 @@ def prepare_conversation(
     else:
         message_id = str(ULID())
 
-    # TODO: Continueが空メッセージという仕様で良いか要検討
-    # Empty messages for continuity purposes are not added.
+    # If the "Generate continue" button is pressed, a new_message is not generated.
     if (
         chat_input.message.content[0].content_type == "text"
         and chat_input.message.content[0].body != ""

--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -261,10 +261,7 @@ def process_chat_input(
         conversation.total_price += arg.price
 
         # If continued, save the state
-        if arg.stop_reason == "max_tokens":
-            conversation.should_continue = True
-        else:
-            conversation.should_continue = False
+        conversation.should_continue = arg.stop_reason == "max_tokens"
 
         # Store conversation before finish streaming so that front-end can avoid 404 issue
         store_conversation(user_id, conversation)

--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -181,7 +181,18 @@ def process_chat_input(
         node_id=chat_input.message.parent_message_id,
         message_map=message_map,
     )
-    messages.append(chat_input.message)  # type: ignore
+
+    continueGenerate = False
+
+    # TODO: 空メッセージだと続けて生成するとしているが、見直しが必要
+    if chat_input.message.content[0].body != "":
+        messages.append(chat_input.message)  # type: ignore
+    else:
+        if messages[-1].role == "assistant":
+            messages[-1].content[0].body = (
+                messages[-1].content[0].body.strip()
+            )  # TODO: ここでstripをすることで、最終的なメッセージに影響が出ないか確認
+        continueGenerate = True
 
     args = compose_args(
         messages,
@@ -203,42 +214,57 @@ def process_chat_input(
         gatewayapi.post_to_connection(ConnectionId=connection_id, Data=data_to_send)
 
     def on_stop(arg: OnStopInput, **kwargs) -> None:
-        used_chunks = None
-        if bot and bot.display_retrieved_chunks:
-            if len(search_results) > 0:
-                used_chunks = []
-                for r in filter_used_results(arg.full_token, search_results):
-                    content_type, source_link = get_source_link(r.source)
-                    used_chunks.append(
-                        ChunkModel(
-                            content=r.content,
-                            content_type=content_type,
-                            source=source_link,
-                            rank=r.rank,
+        if not continueGenerate:
+            used_chunks = None
+            if bot and bot.display_retrieved_chunks:
+                if len(search_results) > 0:
+                    used_chunks = []
+                    for r in filter_used_results(arg.full_token, search_results):
+                        content_type, source_link = get_source_link(r.source)
+                        used_chunks.append(
+                            ChunkModel(
+                                content=r.content,
+                                content_type=content_type,
+                                source=source_link,
+                                rank=r.rank,
+                            )
                         )
-                    )
 
-        # Append entire completion as the last message
-        assistant_msg_id = str(ULID())
-        message = MessageModel(
-            role="assistant",
-            content=[
-                ContentModel(content_type="text", body=arg.full_token, media_type=None)
-            ],
-            model=chat_input.message.model,
-            children=[],
-            parent=user_msg_id,
-            create_time=get_current_time(),
-            feedback=None,
-            used_chunks=used_chunks,
-            thinking_log=None,
-        )
-        conversation.message_map[assistant_msg_id] = message
-        # Append children to parent
-        conversation.message_map[user_msg_id].children.append(assistant_msg_id)
-        conversation.last_message_id = assistant_msg_id
+            # Append entire completion as the last message
+            assistant_msg_id = str(ULID())
+            message = MessageModel(
+                role="assistant",
+                content=[
+                    ContentModel(
+                        content_type="text", body=arg.full_token, media_type=None
+                    )
+                ],
+                model=chat_input.message.model,
+                children=[],
+                parent=user_msg_id,
+                create_time=get_current_time(),
+                feedback=None,
+                used_chunks=used_chunks,
+                thinking_log=None,
+            )
+            conversation.message_map[assistant_msg_id] = message
+            # Append children to parent
+            conversation.message_map[user_msg_id].children.append(assistant_msg_id)
+            conversation.last_message_id = assistant_msg_id
+
+        else:
+            # For continue generate
+            conversation.message_map[conversation.last_message_id].content[
+                0
+            ].body += arg.full_token
 
         conversation.total_price += arg.price
+
+        # If continued, save the state
+        if arg.stop_reason == "max_tokens":
+            conversation.should_continue = True
+        else:
+            conversation.should_continue = False
 
         # Store conversation before finish streaming so that front-end can avoid 404 issue
         store_conversation(user_id, conversation)

--- a/backend/tests/test_repositories/test_conversation.py
+++ b/backend/tests/test_repositories/test_conversation.py
@@ -338,6 +338,7 @@ class TestConversationBotRepository(unittest.TestCase):
             },
             last_message_id="x",
             bot_id=None,
+            should_continue=False,
         )
         conversation2 = ConversationModel(
             id="2",
@@ -368,6 +369,7 @@ class TestConversationBotRepository(unittest.TestCase):
             },
             last_message_id="x",
             bot_id="1",
+            should_continue=False,
         )
         bot1 = BotModel(
             id="1",

--- a/backend/tests/test_repositories/test_conversation.py
+++ b/backend/tests/test_repositories/test_conversation.py
@@ -148,6 +148,7 @@ class TestConversationRepository(unittest.TestCase):
             },
             last_message_id="x",
             bot_id=None,
+            should_continue=False,
         )
 
         # Test storing conversation
@@ -185,6 +186,7 @@ class TestConversationRepository(unittest.TestCase):
         self.assertEqual(found_conversation.last_message_id, "x")
         self.assertEqual(found_conversation.total_price, 100)
         self.assertEqual(found_conversation.bot_id, None)
+        self.assertEqual(found_conversation.should_continue, False)
 
         # Test update title
         response = change_conversation_title(
@@ -259,6 +261,7 @@ class TestConversationRepository(unittest.TestCase):
             message_map=large_message_map,
             last_message_id="msg_9",
             bot_id=None,
+            should_continue=False,
         )
 
         # Test storing large conversation with a small threshold
@@ -274,6 +277,7 @@ class TestConversationRepository(unittest.TestCase):
         self.assertEqual(found_conversation.total_price, 200)
         self.assertEqual(found_conversation.last_message_id, "msg_9")
         self.assertEqual(found_conversation.bot_id, None)
+        self.assertEqual(found_conversation.should_continue, False)
 
         message_map = found_conversation.message_map
         self.assertEqual(len(message_map), 10)

--- a/backend/tests/test_usecases/test_chat.py
+++ b/backend/tests/test_usecases/test_chat.py
@@ -325,6 +325,7 @@ class TestContinueChat(unittest.TestCase):
                     ),
                 },
                 bot_id=None,
+                should_continue=False,
             ),
         )
 
@@ -449,6 +450,7 @@ class TestRegenerateChat(unittest.TestCase):
                     ),
                 },
                 bot_id=None,
+                should_continue=False,
             ),
         )
 

--- a/frontend/src/@types/conversation.d.ts
+++ b/frontend/src/@types/conversation.d.ts
@@ -85,6 +85,7 @@ export type MessageMap = {
 
 export type Conversation = ConversationMeta & {
   messageMap: MessageMap;
+  shouldContinue: boolean;
 };
 
 export type PutFeedbackRequest = {

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -158,11 +158,12 @@ const ChatMessage: React.FC<Props> = (props) => {
                 } else {
                   return (
                     // [Customize]インプットメッセージもMarkdown書式で整形表示できるよう修正
-                    <ChatMessageMarkdown
+                  <ChatMessageMarkdown
+                    key={idx}
                     messageId={String(idx)}>
                     {content.body}
                   </ChatMessageMarkdown>    
-                  );
+                );
                 }
               })}
               <ModalDialog

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -157,11 +157,11 @@ const ChatMessage: React.FC<Props> = (props) => {
                   );
                 } else {
                   return (
-                    <React.Fragment key={idx}>
-                      {content.body.split('\n').map((c, idxBody) => (
-                        <div key={idxBody}>{c}</div>
-                      ))}
-                    </React.Fragment>
+                    // [Customize]インプットメッセージもMarkdown書式で整形表示できるよう修正
+                    <ChatMessageMarkdown
+                    messageId={String(idx)}>
+                    {content.body}
+                  </ChatMessageMarkdown>    
                   );
                 }
               })}

--- a/frontend/src/components/ChatMessageMarkdown.tsx
+++ b/frontend/src/components/ChatMessageMarkdown.tsx
@@ -143,25 +143,35 @@ const ChatMessageMarkdown: React.FC<Props> = ({
       // @ts-ignore
       rehypePlugins={rehypePlugins}
       components={{
+        // [Customize]ファイル名表示できるようにカスタマイズ
+        pre({children}) {
+          return (<pre className='code-container'>{children}</pre>)
+        },
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         code({ node, inline, className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
           const codeText = onlyText(children).replace(/\n$/, '');
+          const filename = match ? className?.split(":")[1] ?? undefined : undefined;
 
           return !inline && match ? (
-            <CopyToClipboard codeText={codeText}>
-              <SyntaxHighlighter
-                {...props}
-                children={codeText}
-                style={vscDarkPlus}
-                language={match[1]}
-                x
-                PreTag="div"
-                wrapLongLines={true}
-              />
-            </CopyToClipboard>
+            // [Customize]ファイル名を表示できるようにカスタマイズ
+            <div>
+              {filename && (<div className="code-header">{filename}</div>)}
+              <CopyToClipboard codeText={codeText}>
+                <SyntaxHighlighter
+                  {...props}
+                  children={codeText}
+                  style={vscDarkPlus}
+                  filename={filename}
+                  language={match[1]}
+                  x
+                  PreTag="div"
+                  wrapLongLines={true}
+                />
+              </CopyToClipboard>
+            </div>
           ) : (
             <code {...props} className={className}>
               {children}

--- a/frontend/src/components/InputChatContent.tsx
+++ b/frontend/src/components/InputChatContent.tsx
@@ -9,7 +9,7 @@ import ButtonSend from './ButtonSend';
 import Textarea from './Textarea';
 import useChat from '../hooks/useChat';
 import Button from './Button';
-import { PiArrowsCounterClockwise, PiX, PiFileTextThin } from 'react-icons/pi';
+import { PiArrowsCounterClockwise, PiX, PiFileTextThin, PiArrowFatLineRight } from 'react-icons/pi';
 import { TbPhotoPlus } from 'react-icons/tb';
 import { useTranslation } from 'react-i18next';
 import ButtonIcon from './ButtonIcon';
@@ -28,6 +28,7 @@ type Props = BaseProps & {
   dndMode?: boolean;
   onSend: (content: string, base64EncodedImages?: string[]) => void;
   onRegenerate: () => void;
+  continueGenerate: () => void;
 };
 
 const MAX_IMAGE_WIDTH = 800;
@@ -99,7 +100,7 @@ const useInputChatContentState = create<{
 
 const InputChatContent: React.FC<Props> = (props) => {
   const { t } = useTranslation();
-  const { postingMessage, hasError, messages } = useChat();
+  const { postingMessage, hasError, messages, getShouldContinue } = useChat();
   const { disabledImageUpload, model, acceptMediaType } = useModel();
 
   const extendedAcceptMediaType = useMemo(() => {
@@ -135,6 +136,10 @@ const InputChatContent: React.FC<Props> = (props) => {
   const disabledRegenerate = useMemo(() => {
     return postingMessage || hasError;
   }, [hasError, postingMessage]);
+
+  const disableContinue = useMemo(() => {
+    return postingMessage || hasError;
+  }, [hasError, postingMessage])
 
   const inputRef = useRef<HTMLDivElement>(null);
 
@@ -355,7 +360,7 @@ const InputChatContent: React.FC<Props> = (props) => {
             <ButtonFileChoose
               disabled={postingMessage}
               icon
-              accept={acceptMediaType.join(',')}
+              accept={extendedAcceptMediaType.join(',')}
               onChange={onChangeImageFile}>
               <TbPhotoPlus />
             </ButtonFileChoose>
@@ -428,15 +433,29 @@ const InputChatContent: React.FC<Props> = (props) => {
             ))}
           </div>
         )}
-        {messages.length > 1 && (
-          <Button
-            className="absolute -top-14 right-0 bg-aws-paper p-2 text-sm"
-            outlined
-            disabled={disabledRegenerate || props.disabled}
-            onClick={props.onRegenerate}>
-            <PiArrowsCounterClockwise className="mr-2" />
-            {t('button.regenerate')}
-          </Button>
+        {(getShouldContinue() || messages.length > 1) && (
+          <div className="absolute -top-14 right-0 flex space-x-2">
+            {getShouldContinue() && (
+              <Button
+                className="bg-aws-paper p-2 text-sm"
+                outlined
+                disabled={disableContinue || props.disabled}
+                onClick={props.continueGenerate}>
+                <PiArrowFatLineRight className="mr-2" />
+                {t('button.continue')}
+              </Button>
+            )}
+            {messages.length > 1 && (
+              <Button
+                className="bg-aws-paper p-2 text-sm"
+                outlined
+                disabled={disabledRegenerate || props.disabled}
+                onClick={props.onRegenerate}>
+                <PiArrowsCounterClockwise className="mr-2" />
+                {t('button.regenerate')}
+              </Button>
+            )}
+          </div>
         )}
       </div>
     </>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -81,6 +81,9 @@ const useChatState = create<{
   setIsGeneratedTitle: (b: boolean) => void;
   getPostedModel: () => Model;
   shouldUpdateMessages: (currentConversation: Conversation) => boolean;
+  shouldCotinue: boolean;
+  setShouldContinue: (b: boolean) => void;
+  getShouldContinue: () => boolean;
 }>((set, get) => {
   return {
     conversationId: '',
@@ -224,6 +227,15 @@ const useChatState = create<{
         get().currentMessageId !== currentConversation.lastMessageId
       );
     },
+    getShouldContinue: () => {
+      return get().shouldCotinue;
+    },
+    setShouldContinue: (b) => {
+      set(() => ({
+        shouldCotinue: b,
+      }));
+    },
+    shouldCotinue: false,
   };
 });
 
@@ -252,6 +264,8 @@ const useChat = () => {
     setRelatedDocuments,
     moveRelatedDocuments,
     shouldUpdateMessages,
+    getShouldContinue,
+    setShouldContinue,
   } = useChatState();
   const { open: openSnackbar } = useSnackbar();
   const navigate = useNavigate();
@@ -299,6 +313,9 @@ const useChat = () => {
       if ((relatedDocuments[NEW_MESSAGE_ID.ASSISTANT]?.length ?? 0) > 0) {
         moveRelatedDocuments(NEW_MESSAGE_ID.ASSISTANT, data.lastMessageId);
       }
+    }
+    if (data && data.shouldContinue !== getShouldContinue()) {
+      setShouldContinue(data.shouldContinue);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId, data]);
@@ -487,6 +504,61 @@ const useChat = () => {
   };
 
   /**
+   * 生成を続ける
+   */
+  const continueGenerate = (params?: {
+    messageId?: string;
+    bot?: BotInputType;
+  }) => {
+    setPostingMessage(true);
+
+    const messageContent: MessageContent = {
+      content: [
+        {
+          body: '',
+          contentType: 'text',
+        },
+      ],
+      model: getPostedModel(),
+      role: 'user',
+      feedback: null,
+      usedChunks: null,
+    };
+    const input: PostMessageRequest = {
+      conversationId: conversationId,
+      message: {
+        ...messageContent,
+        parentMessageId: messages[messages.length - 1].id,
+      },
+      botId: params?.bot?.botId,
+    };
+
+    const currentContentBody = messages[messages.length - 1].content[0].body;
+    const currentMessage = messages[messages.length - 1];
+
+    postStreaming({
+      input,
+      dispatch: (c: string) => {
+        editMessage(conversationId, currentMessage.id, currentContentBody + c);
+      },
+      thinkingDispatch: (event) => {
+        send({ type: event });
+      },
+    })
+      .then(() => {
+        mutate();
+      })
+      .catch((e) => {
+        console.error(e);
+        // setCurrentMessageId(NEW_MESSAGE_ID.USER);
+        // removeMessage(conversationId, NEW_MESSAGE_ID.ASSISTANT);
+      })
+      .finally(() => {
+        setPostingMessage(false);
+      });
+  };
+
+  /**
    * 再生成
    * @param props content: 内容を上書きしたい場合に設定  messageId: 再生成対象のmessageId  botId: ボットの場合は設定する
    */
@@ -620,6 +692,8 @@ const useChat = () => {
     postChat,
     regenerate,
     getPostedModel,
+    getShouldContinue,
+    continueGenerate,
     // エラーのリトライ
     retryPostChat: (params: { content?: string; bot?: BotInputType }) => {
       const length_ = messages.length;

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -172,6 +172,7 @@ Wie würden Sie diese E-Mail kategorisieren?`,
       signOut: 'Abmelden',
       close: 'Schließen',
       add: 'Hinzufügen',
+      continue: 'Weiter generieren',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -397,6 +397,7 @@ How would you categorize this email?`,
       signOut: 'Sign out',
       close: 'Close',
       add: 'Add',
+      continue: 'Continue to generate',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -309,6 +309,7 @@ Las categorías de clasificación son:
       signOut: 'Cerrar sesión',
       close: 'Cerrar',
       add: 'Agregar',
+      continue: 'Seguir generando',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/fr/index.ts
+++ b/frontend/src/i18n/fr/index.ts
@@ -172,6 +172,7 @@ Comment catégoriseriez-vous cet e-mail ?`,
       signOut: 'Se déconnecter',
       close: 'Fermer',
       add: 'Ajouter',
+      continue: 'Continuer à générer',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/it/index.ts
+++ b/frontend/src/i18n/it/index.ts
@@ -332,6 +332,7 @@ Come classificheresti questa email?`,
       signOut: 'Disconnessione',
       close: 'Chiudi',
       add: 'Aggiungi',
+      continue: 'Continuare a generare',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -400,6 +400,7 @@ const translation = {
       signOut: 'サインアウト',
       close: '閉じる',
       add: '追加',
+      continue: '生成を続ける',
     },
     input: {
       hint: {

--- a/frontend/src/i18n/zh-hans/index.ts
+++ b/frontend/src/i18n/zh-hans/index.ts
@@ -329,6 +329,7 @@
         signOut: '退出登录',
         close: '关闭',
         add: '新增',
+        continue: '继续生成',
       },
       input: {
         hint: {

--- a/frontend/src/i18n/zh-hant/index.ts
+++ b/frontend/src/i18n/zh-hant/index.ts
@@ -329,6 +329,7 @@
         signOut: '登出',
         close: '關閉',
         add: '新增',
+        continue: '繼續生成',
       },
       input: {
         hint: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,3 +8,18 @@
     --amplify-components-button-primary-background-color
   ) !important;
 }
+
+.file-name {
+  text-align: center;
+  max-width: 8rem; /* ファイル名の幅 */
+  white-space: pre-wrap; /* 折り返しを有効にする */
+  word-wrap: break-word; /* 長い単語の途中で折り返す */
+}
+
+.code-container {
+  padding: 3px;
+}
+.code-header {
+  margin-left: 18px;
+  margin-top: 5px;
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -49,6 +49,7 @@ const ChatPage: React.FC = () => {
     retryPostChat,
     setCurrentMessageId,
     regenerate,
+    continueGenerate,
     getPostedModel,
     loadingConversation,
   } = useChat();
@@ -159,6 +160,10 @@ const ChatPage: React.FC = () => {
       bot: inputBotParams,
     });
   }, [inputBotParams, regenerate]);
+
+  const onContinueGenerate = useCallback(()=>{
+    continueGenerate({bot: inputBotParams});
+  }, [inputBotParams, continueGenerate])
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -390,6 +395,7 @@ const ChatPage: React.FC = () => {
             }
             onSend={onSend}
             onRegenerate={onRegenerate}
+            continueGenerate={onContinueGenerate}
           />
         )}
       </div>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- テキストファイルのドラッグおよびのファイル添付指定
  -  ただし、指定されたテキストファイルはマークダウン書式のコードブロックとしてプロンプトに挿入される動きとなる
- ユーザ入力の出力を`React.Fragment`から`ChatMessageMarkdown`に変更
- "続きを生成"機能を追加
  - `stop_reason`が`max_tokens`だった場合、続きを生成ボタンを出すように修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
