### PR TITLE
skip CF logging in unsupported regions

### DIFF
--- a/cdk/lib/constructs/frontend.ts
+++ b/cdk/lib/constructs/frontend.ts
@@ -69,10 +69,12 @@ export class Frontend extends Construct {
           responsePagePath: "/",
         },
       ],
-      loggingConfig: {
-        bucket: props.accessLogBucket,
-        prefix: "Frontend/",
-      },
+      ...(!this.shouldSkipAccessLogging() && {
+        loggingConfig: {
+          bucket: props.accessLogBucket,
+          prefix: "Frontend/",
+        },
+      }),
       webACLId: props.webAclId,
     });
 
@@ -166,5 +168,26 @@ export class Frontend extends Construct {
         value: idp.getSocialProviders(),
       });
     }
+  }
+
+  /**
+   * CloudFront does not support access log delivery in the following regions
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#access-logs-choosing-s3-bucket
+   */
+  private shouldSkipAccessLogging(): boolean {
+    const skipLoggingRegions = [
+      "af-south-1",
+      "ap-east-1",
+      "ap-south-2",
+      "ap-southeast-3",
+      "ap-southeast-4",
+      "ca-west-1",
+      "eu-south-1",
+      "eu-south-2",
+      "eu-central-2",
+      "il-central-1",
+      "me-central-1",
+    ];
+    return skipLoggingRegions.includes(Stack.of(this).region);
   }
 }


### PR DESCRIPTION
*Issue #, if available:* #366

*Description of changes:*

CloudFront does not support standard log delivery in all regions, skip defining the logging config in unsupported regions.
Refer to https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#access-logs-choosing-s3-bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
