### PR TITLE
Downgrade numpy v2 to v1

### DIFF
--- a/backend/embedding.requirements.txt
+++ b/backend/embedding.requirements.txt
@@ -21,3 +21,4 @@ retry==0.9.2
 types-retry==0.9.9.4
 aws-lambda-powertools==2.1.0
 duckduckgo_search==6.1.4
+numpy==1.26.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- As of Jun 17, numpy v2.0.0 released ([link](https://github.com/numpy/numpy/releases/tag/v2.0.0)). To resolve dependencies' issue, downgrade numpy to v1.
- This is not a PR for resolve root cause. Need to introcuce package management system asap. #324 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
