### PR TITLE
main.tsxの読み込みエラー時に自動的にcacheを削除して再読み込みするように修正

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
   </head>
   <body class="min-h-dvh font-body">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx" onerror="window.location.reload(true)"></script>
     <!-- Vite＋AmplifyUIの際は以下の設定が必要 -->
     <script>
       window.global = window;


### PR DESCRIPTION
cloudfrontにデプロイを行った際、HTMLがcacheされているせいなのか、存在しないmain.0d256abdf.tsxを要求し失敗して画面がホワイトアウトします。
デプロイ後、毎回必ずshft+f5を行う必要があり煩わしかったのを改善します。