### PR TITLE
Fix: PDF Text Extraction Fails with Character Corruption

### DIFF
--- a/backend/embedding/Dockerfile
+++ b/backend/embedding/Dockerfile
@@ -46,6 +46,12 @@ RUN pip install poetry --no-cache-dir && \
 
 RUN playwright install chromium
 
+# Install NLTK and tokenizers and taggers
+# Ref: https://www.nltk.org/data.html
+RUN python -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger stopwords
+# Set NLTK_DATA environment variable
+ENV NLTK_DATA /usr/local/share/nltk_data
+
 COPY ./embedding ./embedding
 COPY ./app ./app
 


### PR DESCRIPTION
*Issue #, if available:*
close #413

*Description of changes:*
Download NLTK in advance while Docker building process to avoid on-demand download (NLTK is used in `partition` method in `unstructured` module)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
