### PR TITLE
feat: number of NAT gateways is customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ By default, this sample does not restrict the domains for sign-up email addresse
 "allowedSignUpEmailDomains": ["example.com"],
 ```
 
+### Customize Number of NAT Gateway
+
+By default, this sample deploys 2 NAT gateways, but you can change the number of NAT gateways if you don't need 2 NAT gateways to reduce costs. Open `cdk.json` and change this parameter 'number of NAT gateways'.
+
+```ts
+"natgatewayCount": 2
+```
+
 ### External Identity Provider
 
 This sample supports external identity provider. Currently we support [Google](./docs/idp/SET_UP_GOOGLE.md) and [custom OIDC provider](./docs/idp/SET_UP_CUSTOM_OIDC.md).

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -42,6 +42,9 @@ const SELF_SIGN_UP_ENABLED: boolean = app.node.tryGetContext("selfSignUpEnabled"
 const EMBEDDING_CONTAINER_VCPU:number = app.node.tryGetContext("embeddingContainerVcpu")
 const EMBEDDING_CONTAINER_MEMORY:number = app.node.tryGetContext("embeddingContainerMemory")
 
+// how many nat gateways
+const NATGATEWAY_COUNT:number = app.node.tryGetContext("natgatewayCount")
+
 // WAF for frontend
 // 2023/9: Currently, the WAF for CloudFront needs to be created in the North America region (us-east-1), so the stacks are separated
 // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webacl.html
@@ -76,5 +79,6 @@ const chat = new BedrockChatStack(app, `BedrockChatStack`, {
   embeddingContainerVcpu: EMBEDDING_CONTAINER_VCPU,
   embeddingContainerMemory: EMBEDDING_CONTAINER_MEMORY,
   selfSignUpEnabled: SELF_SIGN_UP_ENABLED,
+  natgatewayCount: NATGATEWAY_COUNT,
 });
 chat.addDependency(waf);

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -73,6 +73,6 @@
     },
     "embeddingContainerVcpu": 2048,
     "embeddingContainerMemory": 4096,
-    "natgatewayCount": 1
+    "natgatewayCount": 2
   }
 }

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -72,6 +72,7 @@
       "start": {}
     },
     "embeddingContainerVcpu": 2048,
-    "embeddingContainerMemory": 4096
+    "embeddingContainerMemory": 4096,
+    "natgatewayCount": 1
   }
 }

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -37,6 +37,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly embeddingContainerVcpu: number;
   readonly embeddingContainerMemory: number;
   readonly selfSignUpEnabled: boolean;
+  readonly natgatewayCount: number;
 }
 
 export class BedrockChatStack extends cdk.Stack {
@@ -47,7 +48,9 @@ export class BedrockChatStack extends cdk.Stack {
     });
     const cronSchedule = createCronSchedule(props.rdsSchedules);
 
-    const vpc = new ec2.Vpc(this, "VPC", {});
+    const vpc = new ec2.Vpc(this, "VPC", {
+      natGateways: props.natgatewayCount
+    });
     vpc.publicSubnets.forEach((subnet) => {
       (subnet.node.defaultChild as ec2.CfnSubnet).mapPublicIpOnLaunch = false;
     });

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -32,9 +32,10 @@ describe("Fine-grained Assertions Test", () => {
           start: {},
         },
         enableMistral: false,
-	selfSignUpEnabled: true,
+	      selfSignUpEnabled: true,
         embeddingContainerVcpu: 1024,
         embeddingContainerMemory: 2048,
+        natgatewayCount: 2
       }
     );
     const hasGoogleProviderTemplate = Template.fromStack(
@@ -89,9 +90,10 @@ describe("Fine-grained Assertions Test", () => {
           start: {},
         },
         enableMistral: false,
-	selfSignUpEnabled: true,
+	      selfSignUpEnabled: true,
         embeddingContainerVcpu: 1024,
         embeddingContainerMemory: 2048,
+        natgatewayCount: 2
       }
     );
     const hasOidcProviderTemplate = Template.fromStack(hasOidcProviderStack);
@@ -140,6 +142,7 @@ describe("Fine-grained Assertions Test", () => {
       selfSignUpEnabled: true,
       embeddingContainerVcpu: 1024,
       embeddingContainerMemory: 2048,
+      natgatewayCount: 2
     });
     const template = Template.fromStack(stack);
 
@@ -187,6 +190,7 @@ describe("Scheduler Test", () => {
       selfSignUpEnabled: true,
       embeddingContainerVcpu: 1024,
       embeddingContainerMemory: 2048,
+      natgatewayCount: 2
     });
     const template = Template.fromStack(hasScheduleStack);
     template.hasResourceProperties("AWS::Scheduler::Schedule", {
@@ -217,6 +221,7 @@ describe("Scheduler Test", () => {
       selfSignUpEnabled: true,
       embeddingContainerVcpu: 1024,
       embeddingContainerMemory: 2048,
+      natgatewayCount: 2
     });
     const template = Template.fromStack(defaultStack);
     // The stack should have only 1 rule for exporting the data from ddb to s3

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -32,7 +32,7 @@ describe("Fine-grained Assertions Test", () => {
           start: {},
         },
         enableMistral: false,
-	      selfSignUpEnabled: true,
+        selfSignUpEnabled: true,
         embeddingContainerVcpu: 1024,
         embeddingContainerMemory: 2048,
         natgatewayCount: 2
@@ -90,7 +90,7 @@ describe("Fine-grained Assertions Test", () => {
           start: {},
         },
         enableMistral: false,
-	      selfSignUpEnabled: true,
+        selfSignUpEnabled: true,
         embeddingContainerVcpu: 1024,
         embeddingContainerMemory: 2048,
         natgatewayCount: 2

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -198,6 +198,14 @@ GENERATION_CONFIG = {
 "allowedSignUpEmailDomains": ["example.com"],
 ```
 
+### NAT Gateway数のカスタマイズ
+
+このサンプルはデフォルトでは2つの NAT ゲートウェイがデプロイされますが、2つの NAT ゲートウェイが不要な場合は、NAT ゲートウェイの数を変更してコストを削減できます。`cdk.json`を開き、 `natgatewayCount` のパラメータをを変更してください。
+
+```ts
+"natgatewayCount": 2
+```
+
 ### リソースの削除
 
 cli および CDK を利用されている場合、`cdk destroy`を実行してください。そうでない場合は[CloudFormation](https://console.aws.amazon.com/cloudformation/home)へアクセスし、手動で`BedrockChatStack`および`FrontendWafStack`を削除してください。なお`FrontendWafStack`は `us-east-1` リージョンにあります。

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -200,7 +200,7 @@ GENERATION_CONFIG = {
 
 ### NAT Gateway数のカスタマイズ
 
-このサンプルはデフォルトでは2つの NAT ゲートウェイがデプロイされますが、2つの NAT ゲートウェイが不要な場合は、NAT ゲートウェイの数を変更してコストを削減できます。`cdk.json`を開き、 `natgatewayCount` のパラメータをを変更してください。
+このサンプルはデフォルトでは2つの NAT Gatewayがデプロイされますが、2つの NAT Gatewayが不要な場合は、NAT Gatewayの数を変更してコストを削減できます。`cdk.json`を開き、 `natgatewayCount` のパラメータを変更してください。
 
 ```ts
 "natgatewayCount": 2


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Currentry, We have to deploy more than 2 NAT Gateway. but, In my usecase, I prefer low cost that high availavility.
I want to reduce the count of nat gateway.
So. In this PR, We can customize the number of nat gateway in the `cdk.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
