### PR TITLE
Fix super-easy deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ You can specify the following parameters during deployment to enhance security a
 - **--disable-self-register**: Disable self-registration (default: enabled). If this flag is set, you will need to create all users on cognito and it will not allow users to self register their accounts.
 - **--ipv4-ranges**: Comma-separated list of allowed IPv4 ranges. (default: allow all ipv4 addresses)
 - **--ipv6-ranges**: Comma-separated list of allowed IPv6 ranges. (default: allow all ipv6 addresses)
-- **---disable-ipv6**: Disable connections over IPv6. (default: enabled)
+- **--disable-ipv6**: Disable connections over IPv6. (default: enabled)
 - **--allowed-signup-email-domains**: Comma-separated list of allowed email domains for sign-up. (default: no domain restriction)
-- **--region**: Define the region where bedrock is available. (default: us-east-1)
+- **--bedrock-region**: Define the region where bedrock is available. (default: us-east-1)
 
 #### Example command with parameters:
 
 ```sh
-./bin.sh --disable-self-register --ipv4-ranges "192.0.2.0/25,192.0.2.128/25" --ipv6-ranges "2001:db8:1:2::/64,2001:db8:1:3::/64" --allowed-signup-email-domains "example.com,anotherexample.com" --region "us-west-2"
+./bin.sh --disable-self-register --ipv4-ranges "192.0.2.0/25,192.0.2.128/25" --ipv6-ranges "2001:db8:1:2::/64,2001:db8:1:3::/64" --allowed-signup-email-domains "example.com,anotherexample.com" --bedrock-region "us-west-2"
 ```
 
 - After about 35 minutes, you will get the following output, which you can access from your browser

--- a/bin.sh
+++ b/bin.sh
@@ -41,7 +41,7 @@ IPV4_RANGES=""
 IPV6_RANGES=""
 DISABLE_IPV6="false"
 ALLOWED_SIGN_UP_EMAIL_DOMAINS=""
-REGION="us-east-1"
+BEDROCK_REGION="us-east-1"
 
 # Parse command-line arguments for customization
 while [[ "$#" -gt 0 ]]; do
@@ -50,7 +50,7 @@ while [[ "$#" -gt 0 ]]; do
         --disable-ipv6) DISABLE_IPV6="true" ;;
         --ipv4-ranges) IPV4_RANGES="$2"; shift ;;
         --ipv6-ranges) IPV6_RANGES="$2"; shift ;;
-        --region) REGION="$2"; shift ;;
+        --bedrock-region) BEDROCK_REGION="$2"; shift ;;
         --allowed-signup-email-domains) ALLOWED_SIGN_UP_EMAIL_DOMAINS="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
@@ -72,7 +72,7 @@ aws cloudformation deploy \
   --stack-name $StackName \
   --template-file deploy.yml \
   --capabilities CAPABILITY_IAM \
-  --parameter-overrides AllowSelfRegister=$ALLOW_SELF_REGISTER DisableIpv6=$DISABLE_IPV6 Ipv4Ranges="$IPV4_RANGES" Ipv6Ranges="$IPV6_RANGES" AllowedSignUpEmailDomains="$ALLOWED_SIGN_UP_EMAIL_DOMAINS" Region="$REGION"
+  --parameter-overrides AllowSelfRegister=$ALLOW_SELF_REGISTER DisableIpv6=$DISABLE_IPV6 Ipv4Ranges="$IPV4_RANGES" Ipv6Ranges="$IPV6_RANGES" AllowedSignUpEmailDomains="$ALLOWED_SIGN_UP_EMAIL_DOMAINS" BedrockRegion="$BEDROCK_REGION"
 
 echo "Waiting for the stack creation to complete..."
 echo "NOTE: this stack contains CodeBuild project which will be used for cdk deploy."

--- a/deploy.yml
+++ b/deploy.yml
@@ -17,7 +17,7 @@ Parameters:
   AllowedSignUpEmailDomains:
     Type: String
     Default: "[]"
-  Region:
+  BedrockRegion:
     Type: String
     Default: "us-east-1"
 
@@ -118,8 +118,8 @@ Resources:
             Value: !Ref DisableIpv6
           - Name: ALLOWED_SIGN_UP_EMAIL_DOMAINS
             Value: !Ref AllowedSignUpEmailDomains
-          - Name: REGION
-            Value: !Ref Region
+          - Name: BEDROCK_REGION
+            Value: !Ref BedrockRegion
       ServiceRole:
         Fn::GetAtt:
           - ProjectRole
@@ -127,7 +127,7 @@ Resources:
       Source:
         BuildSpec: |-
           {
-            "version": "0.2",
+            "version": 0.2,
             "phases": {
               "install": {
                 "runtime-versions": {
@@ -145,9 +145,9 @@ Resources:
                   "cd bedrock-claude-chat",
                   "if [ \"$ALLOW_SELF_REGISTER\" = \"false\" ]; then sed -i 's/\"selfSignUpEnabled\": true,/\"selfSignUpEnabled\": false,/' cdk/cdk.json; fi",
                   "if [ ! -z \"$IPV4_RANGES\" ]; then jq --arg ipv4 \"$IPV4_RANGES\" '.context.allowedIpV4AddressRanges = ($ipv4 | split(\",\"))' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; fi",
-                  "if [ "$DISABLE_IPV6" = "true" ]; then jq '.context.allowedIpV6AddressRanges = []' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; elif [ ! -z "$IPV6_RANGES" ]; then jq --arg ipv6 "$IPV6_RANGES" '.context.allowedIpV6AddressRanges = ($ipv6 | split(","))' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; fi",
+                  "if [ \"$DISABLE_IPV6\" = \"true\" ]; then jq '.context.allowedIpV6AddressRanges = []' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; elif [ ! -z \"$IPV6_RANGES\" ]; then jq --arg ipv6 \"$IPV6_RANGES\" '.context.allowedIpV6AddressRanges = ($ipv6 | split(\",\"))' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; fi",
                   "if [ ! -z \"$ALLOWED_SIGN_UP_EMAIL_DOMAINS\" ]; then jq --arg domains \"$ALLOWED_SIGN_UP_EMAIL_DOMAINS\" '.context.allowedSignUpEmailDomains = ($domains | split(\",\"))' cdk/cdk.json > temp.json && mv temp.json cdk/cdk.json; fi",
-                  "sed -i \"s/\\\"bedrockRegion\\\": \\\"[^\\\"]*\\\"/\\\"bedrockRegion\\\": \\\"${REGION}\\\"/\" cdk/cdk.json",
+                  "sed -i \"s/\\\"bedrockRegion\\\": \\\"[^\\\"]*\\\"/\\\"bedrockRegion\\\": \\\"${BEDROCK_REGION}\\\"/\" cdk/cdk.json",
                   "cd cdk",
                   "npm ci",
                   "cdk bootstrap",

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -60,17 +60,17 @@ chmod +x bin.sh
 
 デプロイ時に以下のパラメータを指定することで、セキュリティとカスタマイズを強化できます。
 
-- --disable-self-register: セルフ登録を無効にします（デフォルト: 有効）。このフラグを設定すると、Cognito 上で全てのユーザーを作成する必要があり、ユーザーが自分でアカウントを登録することはできなくなります。
-- --ipv4-ranges: 許可する IPv4 範囲のカンマ区切りリスト。（デフォルト: 全ての IPv4 アドレスを許可）
-- --ipv6-ranges: 許可する IPv6 範囲のカンマ区切りリスト。（デフォルト: 全ての IPv6 アドレスを許可）
-- --disable-ipv6: IPv6 での接続を無効にします (デフォルト: 有効)
-- --allowed-signup-email-domains: サインアップ時に許可するメールドメインのカンマ区切りリスト。（デフォルト: ドメイン制限なし）
-- --region: Bedrock が利用可能なリージョンを指定します。（デフォルト: us-east-1）
+- **--disable-self-register**: セルフ登録を無効にします（デフォルト: 有効）。このフラグを設定すると、Cognito 上で全てのユーザーを作成する必要があり、ユーザーが自分でアカウントを登録することはできなくなります。
+- **--ipv4-ranges**: 許可する IPv4 範囲のカンマ区切りリスト。（デフォルト: 全ての IPv4 アドレスを許可）
+- **--ipv6-ranges**: 許可する IPv6 範囲のカンマ区切りリスト。（デフォルト: 全ての IPv6 アドレスを許可）
+- **--disable-ipv6**: IPv6 での接続を無効にします (デフォルト: 有効)
+- **--allowed-signup-email-domains**: サインアップ時に許可するメールドメインのカンマ区切りリスト。（デフォルト: ドメイン制限なし）
+- **--bedrock-region**: Bedrock が利用可能なリージョンを指定します。（デフォルト: us-east-1）
 
 #### パラメータを指定したコマンド例:
 
 ```sh
-./bin.sh --disable-self-register --ipv4-ranges "192.0.2.0/25,192.0.2.128/25" --ipv6-ranges "2001:db8:1:2::/64,2001:db8:1:3::/64" --allowed-signup-email-domains "example.com,anotherexample.com" --region "ap-northeast-1"
+./bin.sh --disable-self-register --ipv4-ranges "192.0.2.0/25,192.0.2.128/25" --ipv6-ranges "2001:db8:1:2::/64,2001:db8:1:3::/64" --allowed-signup-email-domains "example.com,anotherexample.com" --bedrock-region "ap-northeast-1"
 ```
 
 - 30 分ほど経過後、下記の出力が得られるのでブラウザからアクセスします


### PR DESCRIPTION
*Issue #, if available:*
Closes #441 

*Description of changes:*

- Fix BuildSpec errors of CodeBuild
  - Escape double quotes properly.
  - Change type of `version` from string to number.
- Change argument name: `--region` to `--bedrock-region`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
