### PR TITLE
Add attribute to `BotSummary` to determine whether the bot using Bedrock KnowledgeBase

### DIFF
--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -233,6 +233,10 @@ class BotSummaryOutput(BaseSchema):
     sync_status: type_sync_status
     has_knowledge: bool
     conversation_quick_starters: list[ConversationQuickStarter]
+    owned_and_has_bedrock_knowledge_base: bool = Field(
+        ...,
+        description="Whether the bot has Bedrock KnowledgeBase attributes. Note that if bot alias, always false.",
+    )
 
 
 class BotSwitchVisibilityInput(BaseSchema):

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -268,9 +268,7 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
             ]
         ),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseOutput(
-                **(bot_input.bedrock_knowledge_base.model_dump())
-            )
+            BedrockKnowledgeBaseOutput(**(bot_input.bedrock_knowledge_base.model_dump()))
             if bot_input.bedrock_knowledge_base
             else None
         ),
@@ -344,8 +342,7 @@ def modify_owned_bot(
             tools=[
                 AgentToolModel(name=t.name, description=t.description)
                 for t in [
-                    get_tool_by_name(tool_name)
-                    for tool_name in modify_input.agent.tools
+                    get_tool_by_name(tool_name) for tool_name in modify_input.agent.tools
                 ]
             ]
         )
@@ -394,9 +391,7 @@ def modify_owned_bot(
             ]
         ),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseModel(
-                **modify_input.bedrock_knowledge_base.model_dump()
-            )
+            BedrockKnowledgeBaseModel(**modify_input.bedrock_knowledge_base.model_dump())
             if modify_input.bedrock_knowledge_base
             else None
         ),
@@ -611,6 +606,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 )
                 for starter in bot.conversation_quick_starters
             ],
+            owned_and_has_bedrock_knowledge_base=bot.has_bedrock_knowledge_base(),
         )
 
     except RecordNotFoundError:
@@ -641,6 +637,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                     for starter in alias.conversation_quick_starters
                 ]
             ),
+            owned_and_has_bedrock_knowledge_base=False,
         )
     except RecordNotFoundError:
         pass
@@ -691,6 +688,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                 )
                 for starter in bot.conversation_quick_starters
             ],
+            owned_and_has_bedrock_knowledge_base=False,
         )
     except RecordNotFoundError:
         raise RecordNotFoundError(

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -268,7 +268,9 @@ def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
             ]
         ),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseOutput(**(bot_input.bedrock_knowledge_base.model_dump()))
+            BedrockKnowledgeBaseOutput(
+                **(bot_input.bedrock_knowledge_base.model_dump())
+            )
             if bot_input.bedrock_knowledge_base
             else None
         ),
@@ -342,7 +344,8 @@ def modify_owned_bot(
             tools=[
                 AgentToolModel(name=t.name, description=t.description)
                 for t in [
-                    get_tool_by_name(tool_name) for tool_name in modify_input.agent.tools
+                    get_tool_by_name(tool_name)
+                    for tool_name in modify_input.agent.tools
                 ]
             ]
         )
@@ -391,7 +394,9 @@ def modify_owned_bot(
             ]
         ),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseModel(**modify_input.bedrock_knowledge_base.model_dump())
+            BedrockKnowledgeBaseModel(
+                **modify_input.bedrock_knowledge_base.model_dump()
+            )
             if modify_input.bedrock_knowledge_base
             else None
         ),


### PR DESCRIPTION
*Issue #, if available:*
Related issue: #440 

*Description of changes:*
Add attribute to `BotSummary` to determine whether the bot using Bedrock KnowledgeBase. This option is intended to be utilized on chat screen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
