### PR TITLE
fix: fix error - 2 validation errors for HumanMessage content

### DIFF
--- a/examples/agents/tools/text_to_sql/tool.py
+++ b/examples/agents/tools/text_to_sql/tool.py
@@ -11,6 +11,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,
     CallbackManagerForToolRun,
 )
+from langchain_core.output_parsers import StrOutputParser
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import PromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field, root_validator
@@ -337,7 +338,7 @@ class QuerySQLCheckerTool(BaseSQLDatabaseTool, BaseTool):
                 template=QUERY_CHECKER, input_variables=["dialect", "query"]
             )
             llm = values.get("llm")
-            values["llm_chain"] = prompt | llm  # type: ignore
+            values["llm_chain"] = prompt | llm | StrOutputParser()  # type: ignore
 
         return values
 


### PR DESCRIPTION
*Issue #, if available:*
llm returns like this
```
content='SELECT "screenname", "screentype", "playertype", "clienttype", "screenversion", "deviceid", "pairingcode", "state", "osname", "fwver", "appver", "createdtime", "updatedtime", "description", "ipaddress", "subnet", "modelname", "organizationid", "placeid", "location", "playercapabilityversion", "rmcapabilityversion", "agenttype", "playingthumbnailid", "playingcontentid", "playingcontentname", "playingprogramid", "playingprogramname", "resolution", "standbymode", "hwduid", "securekey", "rm", "player"\nFROM public."dms_screen"\nWHERE "screenid" = \'5F-C5-A2-1E-C9-11\'\nLIMIT 10;' additional_kwargs={'usage': {'prompt_tokens': 410, 'completion_tokens': 209, 'total_tokens': 619}, 'stop_reason': 'end_turn', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'} response_metadata={'usage': {'prompt_tokens': 410, 'completion_tokens': 209, 'total_tokens': 619}, 'stop_reason': 'end_turn', 'model_id': 'anthropic.claude-3-sonnet-20240229-v1:0'} id='run-55883457-174d-4d18-a24c-86fc7848b94a-0' usage_metadata={'input_tokens': 410, 'output_tokens': 209, 'total_tokens': 619}
```

That's why following error occured.

```
ValidationError: 2 validation errors for HumanMessage content str type expected (type=type_error.str) content value is not a valid list (type=type_error.list)
```

*Description of changes:*
So I added StrOutputParser() on the llm_chain, and it works

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
