### PR TITLE
Fix: Cannot remember context/chat history in Published (Bot) API

### DIFF
--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -329,7 +329,8 @@ def chat(user_id: str, chat_input: ChatInput) -> ChatOutput:
             message_map = conversation_with_context.message_map
 
         messages = trace_to_root(
-            node_id=chat_input.message.parent_message_id, message_map=message_map
+            node_id=conversation.message_map[user_msg_id].parent,
+            message_map=message_map,
         )
 
         if not chat_input.continue_generate:

--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -178,7 +178,7 @@ def process_chat_input(
         message_map = conversation_with_context.message_map
 
     messages = trace_to_root(
-        node_id=chat_input.message.parent_message_id,
+        node_id=conversation.message_map[user_msg_id].parent,
         message_map=message_map,
     )
 


### PR DESCRIPTION
- app.usecases.chat.chat()
- app.websocket.process_chat_input()

*Issue #, if available:*
Closes #488 
Closes #497 

*Description of changes:*
Pass the parent's message ID correctly to `trace_to_root()` function.
- `app.usecases.chat.chat()`
- `app.websocket.process_chat_input()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
