### PR TITLE
Fix: Error resolution in environments where ECS runtime monitoring is enabled with guardduty

### DIFF
--- a/cdk/lib/constructs/embedding.ts
+++ b/cdk/lib/constructs/embedding.ts
@@ -156,6 +156,11 @@ export class Embedding extends Construct {
     });
     taskLogGroup.grantWrite(this._container.taskDefinition.executionRole!);
     props.dbSecrets.grantRead(this._container.taskDefinition.taskRole);
+    this._container.taskDefinition.executionRole?.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AmazonECSTaskExecutionRolePolicy"
+      )
+    );
     return this;
   }
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*


## Overview
In an environment where AWS Fargate is enabled in guardduty runtime monitoring, the Guardduty container that starts together with the embedding ECS Task cannot be started, and StepFunctions causes an error.
Since the embedding container itself is successfully processed normally, there is no functional problem, but since stepFunctions becomes an error status, it is difficult to confirm normality.

![Screenshot 2024-08-23 at 14 21 26](https://github.com/user-attachments/assets/4f6c4dd7-638d-4142-9116-bbf225dcd139)
![Screenshot 2024-08-23 at 14 22 18](https://github.com/user-attachments/assets/90336500-c21c-4fd4-b025-9d33766ab816)
![Screenshot 2024-08-23 at 14 22 37](https://github.com/user-attachments/assets/5e113c97-c1be-4705-b29c-078ee6c8b54b)

## How to Resolve
Attach the AmazonECSTaskExecutionRolePolicy managed policy to Fargate's taskExecutionRole.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
