### PR TITLE
Fix "desciription" typo and automatically load agent tool name and description from language file.

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -59,7 +59,6 @@ To develop your own custom tools for the Agent, follow these guidelines:
 
   - Edit i18n files. Open [en/index.ts](../frontend/src/i18n/en/index.ts) and add your own `name` and `description` on `agent.tools`.
   - Edit `xx/index.ts` as well. Where `xx` represents the country code you wish.
-  - Edit [formatDescription.ts](../frontend/src/features/agent/functions/formatDescription.ts) so that frontend app can refer to it correctly.
 
 - Run `cdk deploy` to deploy your changes. This will make your custom tool available in the custom bot screen.
 

--- a/frontend/src/features/agent/functions/formatDescription.ts
+++ b/frontend/src/features/agent/functions/formatDescription.ts
@@ -1,40 +1,12 @@
 import { exists, TFunction } from 'i18next';
 import { AgentTool } from '../types';
 
-// Please add a corresponding case branch for the Tool Name in the following function when the AgentTool returned from the backend is updated.
 export const formatDescription = (tool: AgentTool, t: TFunction) => {
-  switch (tool.name) {
-    case 'get_weather':
-      return `${t(`agent.tools.get_weather.name`)}:${t(
-        `agent.tools.get_weather.description`
-      )}`;
-    case 'sql_db_query':
-      return `${t(`agent.tools.sql_db_query.name`)}:${t(
-        `agent.tools.sql_db_query.description`
-      )}`;
-    case 'sql_db_schema':
-      return `${t(`agent.tools.sql_db_schema.name`)}:${t(
-        `agent.tools.sql_db_schema.description`
-      )}`;
-    case 'sql_db_list_tables':
-      return `${t(`agent.tools.sql_db_list_tables.name`)}:${t(
-        `agent.tools.sql_db_list_tables.description`
-      )}`;
-    case 'sql_db_query_checker':
-      return `${t(`agent.tools.sql_db_query_checker.name`)}:${t(
-        `agent.tools.sql_db_query_checker.description`
-      )}`;
-    case 'internet_search':
-      return `${t(`agent.tools.internet_search.name`)}:${t(
-        `agent.tools.internet_search.description`
-      )}`;
-    default:
-      if (exists(`agent.tools.${tool.name}`)) {
-        return `${t(`agent.tools.${tool.name}.name` as never)}:${t(
-          `agent.tools.${tool.name}.description` as never
-        )}`;
-      }
-
-      return `${tool.name}:${tool.description}`;
+  if (exists(`agent.tools.${tool.name}`)) {
+    return `${t(`agent.tools.${tool.name}.name` as never)}:${t(
+      `agent.tools.${tool.name}.description` as never
+    )}`;
   }
+
+  return `${tool.name}:${tool.description}`;
 };

--- a/frontend/src/features/agent/functions/formatDescription.ts
+++ b/frontend/src/features/agent/functions/formatDescription.ts
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next';
+import { exists, TFunction } from 'i18next';
 import { AgentTool } from '../types';
 
 // Please add a corresponding case branch for the Tool Name in the following function when the AgentTool returned from the backend is updated.
@@ -26,9 +26,15 @@ export const formatDescription = (tool: AgentTool, t: TFunction) => {
       )}`;
     case 'internet_search':
       return `${t(`agent.tools.internet_search.name`)}:${t(
-        `agent.tools.internet_search.desciription`
+        `agent.tools.internet_search.description`
       )}`;
     default:
+      if (exists(`agent.tools.${tool.name}`)) {
+        return `${t(`agent.tools.${tool.name}.name` as never)}:${t(
+          `agent.tools.${tool.name}.description` as never
+        )}`;
+      }
+
       return `${tool.name}:${tool.description}`;
   }
 };

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -50,7 +50,7 @@ const translation = {
         },
         internet_search: {
           name: 'Internet Search',
-          desciription: 'Search the internet for information.',
+          description: 'Search the internet for information.',
         },
       },
     },

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -53,7 +53,7 @@ const translation = {
         },
         internet_search: {
           name: 'インターネット検索',
-          desciription: 'インターネットで情報を検索します。',
+          description: 'インターネットで情報を検索します。',
         },
       },
     },


### PR DESCRIPTION
Modify formatDescription.ts so that when new tools are created and the name and description are defined in the language file it will automatically use the specified name and description

*Issue #, if available:*
No issue #

*Description of changes:*
Fix the "desciription" typo
Automatically load name and description of tool from i18next lanhguage file rather than needing to edit formatDescription.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
