### PR TITLE
feat: Add cross-region inference support for Bedrock models (#535)

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -11,7 +11,12 @@ from app.config import DEFAULT_MISTRAL_GENERATION_CONFIG
 from app.repositories.models.conversation import MessageModel
 from app.repositories.models.custom_bot import GenerationParamsModel
 from app.routes.schemas.conversation import type_model_name
-from app.utils import convert_dict_keys_to_camel_case, get_bedrock_client, is_region_supported_for_inference, ENABLE_BEDROCK_CROSS_REGION_INFERENCE
+from app.utils import (
+    convert_dict_keys_to_camel_case,
+    get_bedrock_client,
+    is_region_supported_for_inference,
+    ENABLE_BEDROCK_CROSS_REGION_INFERENCE,
+)
 from typing_extensions import NotRequired, TypedDict, no_type_check
 
 logger = logging.getLogger(__name__)
@@ -23,7 +28,9 @@ DEFAULT_GENERATION_CONFIG = (
     if ENABLE_MISTRAL
     else DEFAULT_CLAUDE_GENERATION_CONFIG
 )
-ENABLE_BEDROCK_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_BEDROCK_CROSS_REGION_INFERENCE", "false").lower() == "true"
+ENABLE_BEDROCK_CROSS_REGION_INFERENCE = (
+    os.environ.get("ENABLE_BEDROCK_CROSS_REGION_INFERENCE", "false").lower() == "true"
+)
 
 client = get_bedrock_client(BEDROCK_REGION)
 
@@ -257,12 +264,14 @@ def calculate_price(
 
     return input_price * input_tokens / 1000.0 + output_price * output_tokens / 1000.0
 
+
 CROSS_REGION_INFERENCE_MODELS = {
     "claude-v3-sonnet": "anthropic.claude-3-sonnet-20240229-v1:0",
     "claude-v3-haiku": "anthropic.claude-3-haiku-20240307-v1:0",
     "claude-v3-opus": "anthropic.claude-3-opus-20240229-v1:0",
     "claude-v3.5-sonnet": "anthropic.claude-3-5-sonnet-20240620-v1:0",
 }
+
 
 def get_model_id(model: type_model_name) -> str:
     # Ref: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
@@ -278,17 +287,25 @@ def get_model_id(model: type_model_name) -> str:
         "mistral-large": "mistral.mistral-large-2402-v1:0",
     }[model]
 
-    if (ENABLE_BEDROCK_CROSS_REGION_INFERENCE and 
-        is_region_supported_for_inference(BEDROCK_REGION) and 
-        model in CROSS_REGION_INFERENCE_MODELS):
-        logger.info(f"Using cross-region inference for model {model} in region {BEDROCK_REGION}")
+    if (
+        ENABLE_BEDROCK_CROSS_REGION_INFERENCE
+        and is_region_supported_for_inference(BEDROCK_REGION)
+        and model in CROSS_REGION_INFERENCE_MODELS
+    ):
+        logger.info(
+            f"Using cross-region inference for model {model} in region {BEDROCK_REGION}"
+        )
         return base_model_id
     else:
         if ENABLE_BEDROCK_CROSS_REGION_INFERENCE:
             if not is_region_supported_for_inference(BEDROCK_REGION):
-                logger.warning(f"Cross-region inference is enabled, but the region {BEDROCK_REGION} is not supported. Using local model.")
+                logger.warning(
+                    f"Cross-region inference is enabled, but the region {BEDROCK_REGION} is not supported. Using local model."
+                )
             elif model not in CROSS_REGION_INFERENCE_MODELS:
-                logger.warning(f"Cross-region inference is not available for model {model}. Using local model.")
+                logger.warning(
+                    f"Cross-region inference is not available for model {model}. Using local model."
+                )
         return f"{base_model_id}-local"
 
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -51,7 +51,7 @@ def get_bedrock_client(region=BEDROCK_REGION):
     else:
         if ENABLE_BEDROCK_CROSS_REGION_INFERENCE:
             logger.warning(f"Cross-region inference is enabled, but the region {region} is not supported. Using default region.")
-        return boto3.client("bedrock-runtime", region_name=REGION
+        return boto3.client("bedrock-runtime", region_name=REGION)
 
 
 def get_bedrock_agent_client(region=REGION):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -19,7 +19,10 @@ PUBLISH_API_CODEBUILD_PROJECT_NAME = os.environ.get(
     "PUBLISH_API_CODEBUILD_PROJECT_NAME", ""
 )
 DB_SECRETS_ARN = os.environ.get("DB_SECRETS_ARN", "")
-ENABLE_BEDROCK_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_BEDROCK_CROSS_REGION_INFERENCE", "false").lower() == "true"
+ENABLE_BEDROCK_CROSS_REGION_INFERENCE = (
+    os.environ.get("ENABLE_BEDROCK_CROSS_REGION_INFERENCE", "false").lower() == "true"
+)
+
 
 def snake_to_camel(snake_str):
     components = snake_str.split("_")
@@ -41,16 +44,27 @@ def is_running_on_lambda():
 
 
 def is_region_supported_for_inference(region: str) -> bool:
-    supported_regions = ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-west-3', 'eu-central-1']  # Add more as they become available
+    supported_regions = [
+        "us-east-1",
+        "us-west-2",
+        "eu-west-1",
+        "eu-west-3",
+        "eu-central-1",
+    ]  # Add more as they become available
     return region in supported_regions
 
+
 def get_bedrock_client(region=BEDROCK_REGION):
-    if ENABLE_BEDROCK_CROSS_REGION_INFERENCE and is_region_supported_for_inference(region):
+    if ENABLE_BEDROCK_CROSS_REGION_INFERENCE and is_region_supported_for_inference(
+        region
+    ):
         logger.info(f"Using cross-region Bedrock client for region {region}")
         return boto3.client("bedrock-runtime", region_name=region)
     else:
         if ENABLE_BEDROCK_CROSS_REGION_INFERENCE:
-            logger.warning(f"Cross-region inference is enabled, but the region {region} is not supported. Using default region.")
+            logger.warning(
+                f"Cross-region inference is enabled, but the region {region} is not supported. Using default region."
+            )
         return boto3.client("bedrock-runtime", region_name=REGION)
 
 

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -52,6 +52,7 @@
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
     "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
     "enableMistral": false,
+    "enableBedrockCrossRegionInference": false,
     "bedrockRegion": "us-east-1",
     "allowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],
     "allowedIpV6AddressRanges": [


### PR DESCRIPTION
This commit introduces the initial setup for supporting cross-region inference in the Bedrock Chat application.

*Issue #, if available:*
#535 
*Description of changes:*
- Added `is_region_supported_for_inference` function in `utils.py` to check if a region supports inference.
- Modified `get_bedrock_client` function in `utils.py` to use cross-region inference if enabled and the region is supported.
- Updated `get_model_id` function in `bedrock.py` to use the base model ID for cross-region inference if enabled, the region is supported, and the model is included in `CROSS_REGION_INFERENCE_MODELS`. If any of these conditions are not met, it falls back to using the local model ID and logs a warning.
- Added `enableBedrockCrossRegionInference` option to `cdk.json` with the default value set to `false`.

These changes lay the foundation for enabling cross-region inference in the Bedrock Chat application. The feature can be enabled or disabled using the `enableBedrockCrossRegionInference` configuration option in `cdk.json`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
