### PR TITLE
kb-bot-embedding-titan-model-v1 to v2

### DIFF
--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 # Ref: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ChunkingConfiguration.html
 type_kb_chunking_strategy = Literal["default", "fixed_size", "none"]
-type_kb_embeddings_model = Literal["titan_v1", "cohere_multilingual_v3"]
+type_kb_embeddings_model = Literal["titan_v2", "cohere_multilingual_v3"]
 type_kb_search_type = Literal["hybrid", "semantic"]
 
 # OpenSearch Serverless Analyzer

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -117,7 +117,7 @@ class TestCustomBotRepository(unittest.TestCase):
         self.assertEqual(len(bot.conversation_quick_starters), 1)
         self.assertEqual(bot.conversation_quick_starters[0].title, "QS title")
         self.assertEqual(bot.conversation_quick_starters[0].example, "QS example")
-        self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v1")
+        self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v2")
         self.assertEqual(bot.bedrock_knowledge_base.chunking_strategy, "default")
         self.assertEqual(bot.bedrock_knowledge_base.max_tokens, 2000)
         self.assertEqual(bot.bedrock_knowledge_base.overlap_percentage, 0)
@@ -256,7 +256,7 @@ class TestCustomBotRepository(unittest.TestCase):
                 ConversationQuickStarterModel(title="QS title", example="QS example")
             ],
             bedrock_knowledge_base=BedrockKnowledgeBaseModel(
-                embeddings_model="titan_v1",
+                embeddings_model="titan_v2",
                 open_search=OpenSearchParamsModel(
                     analyzer=AnalyzerParamsModel(
                         character_filters=["icu_normalizer"],
@@ -301,7 +301,7 @@ class TestCustomBotRepository(unittest.TestCase):
         self.assertEqual(bot.conversation_quick_starters[0].title, "QS title")
         self.assertEqual(bot.conversation_quick_starters[0].example, "QS example")
 
-        self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v1")
+        self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v2")
         self.assertEqual(bot.bedrock_knowledge_base.chunking_strategy, "default")
         self.assertEqual(bot.bedrock_knowledge_base.max_tokens, 2000)
         self.assertEqual(bot.bedrock_knowledge_base.overlap_percentage, 0)

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -60,7 +60,7 @@ class TestCustomBotRepository(unittest.TestCase):
                 ConversationQuickStarterModel(title="QS title", example="QS example")
             ],
             bedrock_knowledge_base=BedrockKnowledgeBaseModel(
-                embeddings_model="titan_v1",
+                embeddings_model="titan_v2",
                 open_search=OpenSearchParamsModel(
                     analyzer=AnalyzerParamsModel(
                         character_filters=["icu_normalizer"],
@@ -190,7 +190,7 @@ class TestCustomBotRepository(unittest.TestCase):
             False,
             "user1",
             bedrock_knowledge_base=BedrockKnowledgeBaseModel(
-                embeddings_model="titan_v1",
+                embeddings_model="titan_v2",
                 open_search=OpenSearchParamsModel(
                     analyzer=AnalyzerParamsModel(
                         character_filters=["icu_normalizer"],

--- a/cdk/lib/utils/bedrock-knowledge-base-args.ts
+++ b/cdk/lib/utils/bedrock-knowledge-base-args.ts
@@ -13,8 +13,8 @@ export const getEmbeddingModel = (
   embeddingsModel: string
 ): BedrockFoundationModel => {
   switch (embeddingsModel) {
-    case "titan_v1":
-      return BedrockFoundationModel.TITAN_EMBED_TEXT_V1;
+    case "titan_v2":
+      return BedrockFoundationModel.TITAN_EMBED_TEXT_V2_1024;
     case "cohere_multilingual_v3":
       return BedrockFoundationModel.COHERE_EMBED_MULTILINGUAL_V3;
     default:

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -321,7 +321,7 @@ describe("Bedrock Knowledge Base Stack", () => {
         },
       },
       embeddings_model: {
-        S: "titan_v1",
+        S: "titan_v2",
       },
     };
 

--- a/frontend/src/features/knowledgeBase/constants/index.ts
+++ b/frontend/src/features/knowledgeBase/constants/index.ts
@@ -58,7 +58,7 @@ export const DEFAULT_CHUNKING_OVERLAP_PERCENTAGE = 20;
 
 export const EDGE_CHUNKING_MAX_TOKENS = {
   MAX: {
-    titan_v1: 8192,
+    titan_v2: 8192,
     cohere_multilingual_v3: 512,
   },
   MIN: 20,

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -101,15 +101,15 @@ const BotKbEditPage: React.FC = () => {
 
   const [knowledgeBaseId, setKnowledgeBaseId] = useState<string | null>(null); // Send null when creating a new bot
   const [embeddingsModel, setEmbeddingsModel] =
-    useState<EmbeddingsModel>('titan_v1');
+    useState<EmbeddingsModel>('titan_v2');
 
   const embeddingsModelOptions: {
     label: string;
     value: EmbeddingsModel;
   }[] = [
     {
-      label: t('knowledgeBaseSettings.embeddingModel.titan_v1.label'),
-      value: 'titan_v1',
+      label: t('knowledgeBaseSettings.embeddingModel.titan_v2.label'),
+      value: 'titan_v2',
     },
     {
       label: t(

--- a/frontend/src/features/knowledgeBase/types/index.d.ts
+++ b/frontend/src/features/knowledgeBase/types/index.d.ts
@@ -9,7 +9,7 @@ export type BedrockKnowledgeBase = {
   searchParams: SearchParams;
 };
 
-export type EmbeddingsModel = 'titan_v1' | 'cohere_multilingual_v3';
+export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
 
 export type ChunkingStrategy = 'default' | 'fixed_size' | 'none';
 

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -520,8 +520,8 @@ How would you categorize this email?`,
         'Select the embedded model for configuring knowledge, and set the method for splitting documents added as knowledge. These settings cannot be changed after creating the bot.',
       embeddingModel: {
         label: 'Embeddings Model',
-        titan_v1: {
-          label: 'Titan Embeddings G1 - Text v1.2',
+        titan_v2: {
+          label: 'Titan Embedding Text v2',
         },
         cohere_multilingual_v3: {
           label: 'Embed Multilingual v3',


### PR DESCRIPTION
*Issue #543

*Description of changes:*
- 'titan_v1' change to 'titan_v2' in each files.
- BedrockFoundationModel.TITAN_EMBED_TEXT_V2_1024 use in bedrock-knowledge-base-args.ts
