### PR TITLE
Bug fix: re-attach log permission to lambdas

### DIFF
--- a/cdk/lib/api-publishment-stack.ts
+++ b/cdk/lib/api-publishment-stack.ts
@@ -39,6 +39,11 @@ export class ApiPublishmentStack extends Stack {
     const handlerRole = new iam.Role(this, "HandlerRole", {
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
     });
+    handlerRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AWSLambdaBasicExecutionRole"
+      )
+    );
     handlerRole.addToPolicy(
       // Assume the table access role for row-level access control.
       new iam.PolicyStatement({

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -56,6 +56,11 @@ export class Api extends Construct {
     const handlerRole = new iam.Role(this, "HandlerRole", {
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
     });
+    handlerRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AWSLambdaBasicExecutionRole"
+      )
+    );
     handlerRole.addToPolicy(
       // Assume the table access role for row-level access control.
       new iam.PolicyStatement({

--- a/cdk/lib/constructs/websocket.ts
+++ b/cdk/lib/constructs/websocket.ts
@@ -62,6 +62,11 @@ export class WebSocket extends Construct {
     const handlerRole = new iam.Role(this, "HandlerRole", {
       assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
     });
+    handlerRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AWSLambdaBasicExecutionRole"
+      )
+    );
     handlerRole.addToPolicy(
       // Assume the table access role for row-level access control.
       new iam.PolicyStatement({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Solved the issue of logs not being output due to the removal of the `AWSLambdaVPCAccessExecutionRole` policy in the [pull request for the v2 release](https://github.com/aws-samples/bedrock-claude-chat/pull/561/files#diff-f74bedfae85c7ecd02e12f63b8aba8d8bd935729f9468a7aaa6075aaece30454L81-L85)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
