### PR TITLE
Fix: continue generate not working

### DIFF
--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -286,11 +286,13 @@ def process_chat_input(
 
     # Leaf node id
     # If `continue_generate` is True, note that new message is not added to the message map.
-    node_id = ""
-    if chat_input.continue_generate:
-        node_id = chat_input.message.parent_message_id
-    else:
-        node_id = conversation.message_map[user_msg_id].parent
+    node_id = (
+        chat_input.message.parent_message_id
+        if chat_input.continue_generate
+        else conversation.message_map[user_msg_id].parent
+    )
+    if node_id is None:
+        raise ValueError("parent_message_id or parent is None")
 
     messages = trace_to_root(
         node_id=node_id,

--- a/backend/app/websocket.py
+++ b/backend/app/websocket.py
@@ -284,8 +284,16 @@ def process_chat_input(
         )
         message_map = conversation_with_context.message_map
 
+    # Leaf node id
+    # If `continue_generate` is True, note that new message is not added to the message map.
+    node_id = ""
+    if chat_input.continue_generate:
+        node_id = chat_input.message.parent_message_id
+    else:
+        node_id = conversation.message_map[user_msg_id].parent
+
     messages = trace_to_root(
-        node_id=conversation.message_map[user_msg_id].parent,
+        node_id=node_id,
         message_map=message_map,
     )
     if not chat_input.continue_generate:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The recent changes in PR #500, aimed at fixing a bug in the public API, have caused the "continue generate" functionality to stop working. The issue stems from the inability to retrieve the conversation leaf node ID. This PR addresses and resolves that problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
