### PR TITLE
feat: Cross region inference for v2

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -3,9 +3,8 @@ import logging
 import os
 from datetime import datetime
 from typing import Any, Literal
-
-import boto3
 from app.repositories.models.custom_bot_guardrails import BedrockGuardrailsModel
+import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
 
@@ -16,6 +15,9 @@ BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-east-1")
 PUBLISH_API_CODEBUILD_PROJECT_NAME = os.environ.get(
     "PUBLISH_API_CODEBUILD_PROJECT_NAME", ""
 )
+ENABLE_BEDROCK_CROSS_REGION_INFERENCE = os.environ.get(
+    "ENABLE_BEDROCK_CROSS_REGION_INFERENCE", "false"
+).lower() == "true"
 
 
 def snake_to_camel(snake_str):
@@ -38,7 +40,7 @@ def is_running_on_lambda():
 
 
 def get_bedrock_client(region=BEDROCK_REGION):
-    client = boto3.client("bedrock", region)
+    client = boto3.client("bedrock", region_name=region)
     return client
 
 
@@ -47,8 +49,9 @@ def get_bedrock_runtime_client(region=BEDROCK_REGION):
     return client
 
 
+
 def get_bedrock_agent_client(region=BEDROCK_REGION):
-    client = boto3.client("bedrock-agent-runtime", region)
+    client = boto3.client("bedrock-agent-runtime", region_name=region)
     return client
 
 

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -51,6 +51,7 @@
     "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
     "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "enableBedrockCrossRegionInference": false,
     "enableMistral": false,
     "bedrockRegion": "us-east-1",
     "allowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],


### PR DESCRIPTION
Issue #535, if available:

Description of changes:

### 🚨 NOTE: Accidentally erased the previous PR while trying to pull the changes from the most recent commits. 🙏🏽 

This new PR addresses the points made by @statefb 

Previous PR: https://github.com/aws-samples/bedrock-claude-chat/pull/571

## utils.py

1. Added `ENABLE_BEDROCK_CROSS_REGION_INFERENCE` which determines if cross-region inference is enabled.
2. Added `SUPPORTED_REGIONS` which is a constant list of regions that support cross-region inference.
3. Renamed `is_region_supported_for_inference` to `is_region_supported_for_cross_inference(region: str)` to emphasize its purpose for cross-region inference.
4. Modified `get_bedrock_runtime_client` to add logic which checks if cross-region inference is enabled and if the region is supported. If both conditions are met, it initializes the Bedrock Runtime client for the specified region. If not, it logs a warning and defaults to using `BEDROCK_REGION`.
5. Ensured `BEDROCK_REGION` is used consistently aligning with @statefb's comments in feat: Add cross-region inference support for Bedrock models (#535) #536

## bedrock.py

- Imported is_region_supported_for_cross_inference and `ENABLE_BEDROCK_CROSS_REGION_INFERENCE` from utils.py
- Adjusted get_model_id function.
- Moved `CROSS_REGION_INFERENCE_MODELS` inside the `get_model_id` function, as it's only used there.
- Added logic to check if cross-region inference is enabled, the region is supported, and the model supports cross-region inference.
- If all conditions are met, returns the base model ID for cross-region inference.
- If not, logs appropriate warnings and adjusts the model ID to use the local model. Included comments to explain the adjustments made to model IDs for local inference, addressing the concern about prefixes and suffixes
- Ensured `BEDROCK_REGION` is used throughout for Bedrock services.

Credit to @chm10 for the initial implementation in version v1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.