### PR TITLE
Fix: Bot before v2.1.1 no longer work

### DIFF
--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -470,7 +470,14 @@ def find_private_bot_by_id(user_id: str, bot_id: str) -> BotModel:
         display_retrieved_chunks=item.get("DisplayRetrievedChunks", False),
         conversation_quick_starters=item.get("ConversationQuickStarters", []),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseModel(**item["BedrockKnowledgeBase"])
+            BedrockKnowledgeBaseModel(
+                **{
+                    **item["BedrockKnowledgeBase"],
+                    "chunking_configuration": item["BedrockKnowledgeBase"].get(
+                        "chunking_configuration", None
+                    ),
+                }
+            )
             if "BedrockKnowledgeBase" in item
             else None
         ),
@@ -541,7 +548,14 @@ def find_public_bot_by_id(bot_id: str) -> BotModel:
         display_retrieved_chunks=item.get("DisplayRetrievedChunks", False),
         conversation_quick_starters=item.get("ConversationQuickStarters", []),
         bedrock_knowledge_base=(
-            BedrockKnowledgeBaseModel(**item["BedrockKnowledgeBase"])
+            BedrockKnowledgeBaseModel(
+                **{
+                    **item["BedrockKnowledgeBase"],
+                    "chunking_configuration": item["BedrockKnowledgeBase"].get(
+                        "chunking_configuration", None
+                    ),
+                }
+            )
             if "BedrockKnowledgeBase" in item
             else None
         ),

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -61,6 +61,7 @@ class BedrockKnowledgeBaseModel(BaseModel):
         | HierarchicalParamsModel
         | SemanticParamsModel
         | NoneParamsModel
+        | None
     )
     search_params: SearchParamsModel
     knowledge_base_id: str | None = None

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -95,6 +95,7 @@ class BedrockKnowledgeBaseOutput(BaseSchema):
         | HierarchicalParams
         | SemanticParams
         | NoneParams
+        | None
     )
     search_params: SearchParams
     knowledge_base_id: str | None = None

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -33,6 +33,7 @@ from app.repositories.models.custom_bot_guardrails import BedrockGuardrailsModel
 from app.repositories.models.custom_bot_kb import (
     AnalyzerParamsModel,
     BedrockKnowledgeBaseModel,
+    FixedSizeParamsModel,
     OpenSearchParamsModel,
 )
 from app.repositories.models.custom_bot_kb import (
@@ -71,9 +72,11 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_results=20,
                     search_type="hybrid",
                 ),
-                chunking_strategy="default",
-                max_tokens=2000,
-                overlap_percentage=0,
+                chunking_configuration=FixedSizeParamsModel(
+                    chunking_strategy="fixed_size",
+                    max_tokens=2000,
+                    overlap_percentage=0,
+                ),
             ),
             bedrock_guardrails=BedrockGuardrailsModel(
                 is_guardrail_enabled=True,
@@ -118,9 +121,13 @@ class TestCustomBotRepository(unittest.TestCase):
         self.assertEqual(bot.conversation_quick_starters[0].title, "QS title")
         self.assertEqual(bot.conversation_quick_starters[0].example, "QS example")
         self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v2")
-        self.assertEqual(bot.bedrock_knowledge_base.chunking_strategy, "default")
-        self.assertEqual(bot.bedrock_knowledge_base.max_tokens, 2000)
-        self.assertEqual(bot.bedrock_knowledge_base.overlap_percentage, 0)
+        self.assertEqual(
+            bot.bedrock_knowledge_base.chunking_configuration.max_tokens, 2000
+        )
+        self.assertEqual(
+            bot.bedrock_knowledge_base.chunking_configuration.overlap_percentage, 0
+        )
+
         self.assertEqual(
             bot.bedrock_knowledge_base.open_search.analyzer.character_filters,
             ["icu_normalizer"],
@@ -212,9 +219,9 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_results=20,
                     search_type="hybrid",
                 ),
-                chunking_strategy="default",
-                max_tokens=2000,
-                overlap_percentage=0,
+                chunking_configuration=FixedSizeParamsModel(
+                    chunking_strategy="fixed_size",
+                ),
             ),
         )
         store_bot("user1", bot)
@@ -272,9 +279,11 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_results=20,
                     search_type="hybrid",
                 ),
-                chunking_strategy="default",
-                max_tokens=2000,
-                overlap_percentage=0,
+                chunking_configuration=FixedSizeParamsModel(
+                    chunking_strategy="fixed_size",
+                    max_tokens=2500,
+                    overlap_percentage=20,
+                ),
             ),
             bedrock_guardrails=BedrockGuardrailsModel(
                 is_guardrail_enabled=True,
@@ -314,9 +323,12 @@ class TestCustomBotRepository(unittest.TestCase):
         self.assertEqual(bot.conversation_quick_starters[0].example, "QS example")
 
         self.assertEqual(bot.bedrock_knowledge_base.embeddings_model, "titan_v2")
-        self.assertEqual(bot.bedrock_knowledge_base.chunking_strategy, "default")
-        self.assertEqual(bot.bedrock_knowledge_base.max_tokens, 2000)
-        self.assertEqual(bot.bedrock_knowledge_base.overlap_percentage, 0)
+        self.assertEqual(
+            bot.bedrock_knowledge_base.chunking_configuration.max_tokens, 2500
+        )
+        self.assertEqual(
+            bot.bedrock_knowledge_base.chunking_configuration.overlap_percentage, 20
+        )
         self.assertEqual(
             bot.bedrock_knowledge_base.open_search.analyzer.character_filters,
             ["icu_normalizer"],


### PR DESCRIPTION
*Issue #, if available:*
Related PR: #569 

*Description of changes:*
On the PR #569, the schema has been changed, causes 422 error on pydantic.  
As a temporary measure, for parts where backward compatibility cannot be maintained (specifically, `chunking_configuration`), the system will return `None`.   
This approach is chosen to avoid excessive complexity in the code. While this solution may create a mismatch in settings such as `"default"`, `"fixed_size"`, or `"none"` in the UI when editing the bot, the current specifications of the KnowledgeBase prevent re-creation, so it is deemed not to be an issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
