### PR TITLE
feat: Add Web Crawler for Knowledge Bases

### DIFF
--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -5,6 +5,7 @@ from app.routes.schemas.bot_kb import (
     type_os_character_filter,
     type_os_token_filter,
     type_os_tokenizer,
+    type_kb_parsing_model,
 )
 from pydantic import BaseModel
 
@@ -66,3 +67,4 @@ class BedrockKnowledgeBaseModel(BaseModel):
     search_params: SearchParamsModel
     knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
+    parsing_model: type_kb_parsing_model = "disabled"

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -7,7 +7,6 @@ from app.routes.schemas.bot_kb import (
     type_os_tokenizer,
     type_kb_parsing_model,
     type_kb_web_crawling_scope,
-    WebCrawlingFilters,
 )
 from pydantic import BaseModel
 
@@ -55,6 +54,11 @@ class NoneParamsModel(BaseModel):
     chunking_strategy: type_kb_chunking_strategy = "none"
 
 
+class WebCrawlingFilters(BaseModel):
+    exclude_patterns: list[str]
+    include_patterns: list[str]
+
+
 class BedrockKnowledgeBaseModel(BaseModel):
     embeddings_model: type_kb_embeddings_model
     open_search: OpenSearchParamsModel
@@ -71,6 +75,6 @@ class BedrockKnowledgeBaseModel(BaseModel):
     data_source_ids: list[str] | None = None
     parsing_model: type_kb_parsing_model = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
-    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+    web_crawling_filters: WebCrawlingFilters = WebCrawlingFilters(
         exclude_patterns=[], include_patterns=[]
     )

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -6,6 +6,8 @@ from app.routes.schemas.bot_kb import (
     type_os_token_filter,
     type_os_tokenizer,
     type_kb_parsing_model,
+    type_kb_web_crawling_scope,
+    WebCrawlingFilters,
 )
 from pydantic import BaseModel
 
@@ -68,3 +70,7 @@ class BedrockKnowledgeBaseModel(BaseModel):
     knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
     parsing_model: type_kb_parsing_model = "disabled"
+    web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
+    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+        exclude_patterns=[], include_patterns=[]
+    )

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -1,12 +1,12 @@
 from app.routes.schemas.bot_kb import (
     type_kb_chunking_strategy,
     type_kb_embeddings_model,
+    type_kb_parsing_model,
     type_kb_search_type,
+    type_kb_web_crawling_scope,
     type_os_character_filter,
     type_os_token_filter,
     type_os_tokenizer,
-    type_kb_parsing_model,
-    type_kb_web_crawling_scope,
 )
 from pydantic import BaseModel
 
@@ -54,7 +54,7 @@ class NoneParamsModel(BaseModel):
     chunking_strategy: type_kb_chunking_strategy = "none"
 
 
-class WebCrawlingFilters(BaseModel):
+class WebCrawlingFiltersModel(BaseModel):
     exclude_patterns: list[str]
     include_patterns: list[str]
 
@@ -75,6 +75,6 @@ class BedrockKnowledgeBaseModel(BaseModel):
     data_source_ids: list[str] | None = None
     parsing_model: type_kb_parsing_model = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
-    web_crawling_filters: WebCrawlingFilters = WebCrawlingFilters(
+    web_crawling_filters: WebCrawlingFiltersModel = WebCrawlingFiltersModel(
         exclude_patterns=[], include_patterns=[]
     )

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -122,6 +122,38 @@ class BotModifyInput(BaseSchema):
             or len(self.knowledge.deleted_filenames) > 0
         )
 
+    def has_update_source_urls(self, current_bot_model: BotModel) -> bool:
+        return self.knowledge is not None and (
+            len(self.knowledge.source_urls) > 0
+            and (
+                set(self.knowledge.source_urls)
+                != set(current_bot_model.knowledge.source_urls)
+            )
+        )
+
+    def modified_crawling_scope(self, current_bot_model: BotModel) -> bool:
+        if self.bedrock_knowledge_base is None or current_bot_model.bedrock_knowledge_base is None:
+            return False
+        return (
+            self.bedrock_knowledge_base.web_crawling_scope
+            != current_bot_model.bedrock_knowledge_base.web_crawling_scope
+        )
+
+    def modified_crawling_filters(self, current_bot_model: BotModel) -> bool:
+        if (
+            self.bedrock_knowledge_base is None
+            or current_bot_model.bedrock_knowledge_base is None
+            or self.bedrock_knowledge_base.web_crawling_filters is None
+            or current_bot_model.bedrock_knowledge_base.web_crawling_filters is None
+        ):
+            return False
+        return (
+            set(self.bedrock_knowledge_base.web_crawling_filters.exclude_patterns)
+            != set(current_bot_model.bedrock_knowledge_base.web_crawling_filters.exclude_patterns)
+            or set(self.bedrock_knowledge_base.web_crawling_filters.include_patterns)
+            != set(current_bot_model.bedrock_knowledge_base.web_crawling_filters.include_patterns)
+        )
+
     def guardrails_update_required(self, current_bot_model: BotModel) -> bool:
         # Check if self.bedrock_guardrails is None
         if not self.bedrock_guardrails:
@@ -152,6 +184,15 @@ class BotModifyInput(BaseSchema):
 
     def is_embedding_required(self, current_bot_model: BotModel) -> bool:
         if self.has_update_files():
+            return True
+
+        if self.has_update_source_urls(current_bot_model):
+            return True
+
+        if self.modified_crawling_scope(current_bot_model):
+            return True
+
+        if self.modified_crawling_filters(current_bot_model):
             return True
 
         if self.knowledge is not None and current_bot_model.has_knowledge():

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -132,7 +132,10 @@ class BotModifyInput(BaseSchema):
         )
 
     def modified_crawling_scope(self, current_bot_model: BotModel) -> bool:
-        if self.bedrock_knowledge_base is None or current_bot_model.bedrock_knowledge_base is None:
+        if (
+            self.bedrock_knowledge_base is None
+            or current_bot_model.bedrock_knowledge_base is None
+        ):
             return False
         return (
             self.bedrock_knowledge_base.web_crawling_scope
@@ -147,11 +150,14 @@ class BotModifyInput(BaseSchema):
             or current_bot_model.bedrock_knowledge_base.web_crawling_filters is None
         ):
             return False
-        return (
-            set(self.bedrock_knowledge_base.web_crawling_filters.exclude_patterns)
-            != set(current_bot_model.bedrock_knowledge_base.web_crawling_filters.exclude_patterns)
-            or set(self.bedrock_knowledge_base.web_crawling_filters.include_patterns)
-            != set(current_bot_model.bedrock_knowledge_base.web_crawling_filters.include_patterns)
+        return set(
+            self.bedrock_knowledge_base.web_crawling_filters.exclude_patterns
+        ) != set(
+            current_bot_model.bedrock_knowledge_base.web_crawling_filters.exclude_patterns
+        ) or set(
+            self.bedrock_knowledge_base.web_crawling_filters.include_patterns
+        ) != set(
+            current_bot_model.bedrock_knowledge_base.web_crawling_filters.include_patterns
         )
 
     def guardrails_update_required(self, current_bot_model: BotModel) -> bool:

--- a/backend/app/routes/schemas/bot.py
+++ b/backend/app/routes/schemas/bot.py
@@ -116,13 +116,13 @@ class BotModifyInput(BaseSchema):
     bedrock_knowledge_base: BedrockKnowledgeBaseInput | None = None
     bedrock_guardrails: BedrockGuardrailsInput | None = None
 
-    def has_update_files(self) -> bool:
+    def _has_update_files(self) -> bool:
         return self.knowledge is not None and (
             len(self.knowledge.added_filenames) > 0
             or len(self.knowledge.deleted_filenames) > 0
         )
 
-    def has_update_source_urls(self, current_bot_model: BotModel) -> bool:
+    def _has_update_source_urls(self, current_bot_model: BotModel) -> bool:
         return self.knowledge is not None and (
             len(self.knowledge.source_urls) > 0
             and (
@@ -131,7 +131,7 @@ class BotModifyInput(BaseSchema):
             )
         )
 
-    def modified_crawling_scope(self, current_bot_model: BotModel) -> bool:
+    def _is_crawling_scope_modified(self, current_bot_model: BotModel) -> bool:
         if (
             self.bedrock_knowledge_base is None
             or current_bot_model.bedrock_knowledge_base is None
@@ -142,7 +142,7 @@ class BotModifyInput(BaseSchema):
             != current_bot_model.bedrock_knowledge_base.web_crawling_scope
         )
 
-    def modified_crawling_filters(self, current_bot_model: BotModel) -> bool:
+    def _is_crawling_filters_modified(self, current_bot_model: BotModel) -> bool:
         if (
             self.bedrock_knowledge_base is None
             or current_bot_model.bedrock_knowledge_base is None
@@ -160,7 +160,7 @@ class BotModifyInput(BaseSchema):
             current_bot_model.bedrock_knowledge_base.web_crawling_filters.include_patterns
         )
 
-    def guardrails_update_required(self, current_bot_model: BotModel) -> bool:
+    def is_guardrails_update_required(self, current_bot_model: BotModel) -> bool:
         # Check if self.bedrock_guardrails is None
         if not self.bedrock_guardrails:
             return False
@@ -189,16 +189,16 @@ class BotModifyInput(BaseSchema):
         return False
 
     def is_embedding_required(self, current_bot_model: BotModel) -> bool:
-        if self.has_update_files():
+        if self._has_update_files():
             return True
 
-        if self.has_update_source_urls(current_bot_model):
+        if self._has_update_source_urls(current_bot_model):
             return True
 
-        if self.modified_crawling_scope(current_bot_model):
+        if self._is_crawling_scope_modified(current_bot_model):
             return True
 
-        if self.modified_crawling_filters(current_bot_model):
+        if self._is_crawling_filters_modified(current_bot_model):
             return True
 
         if self.knowledge is not None and current_bot_model.has_knowledge():

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -95,7 +95,7 @@ class BedrockKnowledgeBaseInput(BaseSchema):
     knowledge_base_id: str | None = None
     parsing_model: type_kb_parsing_model = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
-    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+    web_crawling_filters: WebCrawlingFilters = WebCrawlingFilters(
         exclude_patterns=[], include_patterns=[]
     )
 
@@ -116,6 +116,6 @@ class BedrockKnowledgeBaseOutput(BaseSchema):
     data_source_ids: list[str] | None = None
     parsing_model: type_kb_parsing_model = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
-    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+    web_crawling_filters: WebCrawlingFilters = WebCrawlingFilters(
         exclude_patterns=[], include_patterns=[]
     )

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -13,7 +13,9 @@ type_kb_chunking_strategy = Literal[
 ]
 type_kb_embeddings_model = Literal["titan_v2", "cohere_multilingual_v3"]
 type_kb_search_type = Literal["hybrid", "semantic"]
-type_kb_parsing_model = Literal["anthropic.claude-3-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"]
+type_kb_parsing_model = Literal[
+    "anthropic.claude-3-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"
+]
 
 # OpenSearch Serverless Analyzer
 # Ref: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -13,6 +13,7 @@ type_kb_chunking_strategy = Literal[
 ]
 type_kb_embeddings_model = Literal["titan_v2", "cohere_multilingual_v3"]
 type_kb_search_type = Literal["hybrid", "semantic"]
+type_kb_parsing_model = Literal["anthropic.claude-3-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"]
 
 # OpenSearch Serverless Analyzer
 # Ref: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html
@@ -84,6 +85,7 @@ class BedrockKnowledgeBaseInput(BaseSchema):
     )
     search_params: SearchParams
     knowledge_base_id: str | None = None
+    parsing_model: type_kb_parsing_model = "disabled"
 
 
 class BedrockKnowledgeBaseOutput(BaseSchema):
@@ -100,3 +102,4 @@ class BedrockKnowledgeBaseOutput(BaseSchema):
     search_params: SearchParams
     knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
+    parsing_model: type_kb_parsing_model = "disabled"

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -16,6 +16,7 @@ type_kb_search_type = Literal["hybrid", "semantic"]
 type_kb_parsing_model = Literal[
     "anthropic.claude-3-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"
 ]
+type_kb_web_crawling_scope = Literal["DEFAULT", "HOST_ONLY", "SUBDOMAINS"]
 
 # OpenSearch Serverless Analyzer
 # Ref: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-genref.html
@@ -75,6 +76,11 @@ class NoneParams(BaseSchema):
     chunking_strategy: type_kb_chunking_strategy = "none"
 
 
+class WebCrawlingFilters(BaseSchema):
+    exclude_patterns: list[str] = Field(default_factory=list)
+    include_patterns: list[str] = Field(default_factory=list)
+
+
 class BedrockKnowledgeBaseInput(BaseSchema):
     embeddings_model: type_kb_embeddings_model
     open_search: OpenSearchParams
@@ -88,6 +94,10 @@ class BedrockKnowledgeBaseInput(BaseSchema):
     search_params: SearchParams
     knowledge_base_id: str | None = None
     parsing_model: type_kb_parsing_model = "disabled"
+    web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
+    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+        exclude_patterns=[], include_patterns=[]
+    )
 
 
 class BedrockKnowledgeBaseOutput(BaseSchema):
@@ -105,3 +115,7 @@ class BedrockKnowledgeBaseOutput(BaseSchema):
     knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
     parsing_model: type_kb_parsing_model = "disabled"
+    web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
+    web_crawling_filters: WebCrawlingFilters | None = WebCrawlingFilters(
+        exclude_patterns=[], include_patterns=[]
+    )

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -317,7 +317,7 @@ def modify_owned_bot(
     sync_status = (
         "QUEUED"
         if modify_input.is_embedding_required(bot)
-        or modify_input.guardrails_update_required(bot)
+        or modify_input.is_guardrails_update_required(bot)
         else "SUCCEEDED"
     )
 

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -74,8 +74,8 @@ def get_source_link(source: str) -> tuple[Literal["s3", "url"], str]:
     elif source.startswith("http://") or source.startswith("https://"):
         return "url", source
     else:
-        # Assume source is a youtube video id
-        return "url", f"https://www.youtube.com/watch?v={source}"
+        # Return the source as is for knowledge base references
+        return "url", source
 
 
 def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResult]:
@@ -102,18 +102,31 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
             },
         )
 
+        def extract_source_from_retrieval_result(retrieval_result):
+            """Extract source URL/URI from retrieval result based on location type."""
+            location = retrieval_result.get("location", {})
+            location_type = location.get("type")
+
+            if location_type == "WEB":
+                return location.get("webLocation", {}).get("url", "")
+            elif location_type == "S3":
+                return location.get("s3Location", {}).get("uri", "")
+            return ""
+
         search_results = []
         for i, retrieval_result in enumerate(response.get("retrievalResults", [])):
             content = retrieval_result.get("content", {}).get("text", "")
-            source = (
-                retrieval_result.get("location", {})
-                .get("s3Location", {})
-                .get("uri", "")
-            )
-
+            source = extract_source_from_retrieval_result(retrieval_result)
+            
             search_results.append(
-                SearchResult(rank=i, bot_id=bot.id, content=content, source=source)
+                SearchResult(
+                    rank=i,
+                    bot_id=bot.id,
+                    content=content,
+                    source=source
+                )
             )
+        
 
         return search_results
 

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -117,16 +117,10 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
         for i, retrieval_result in enumerate(response.get("retrievalResults", [])):
             content = retrieval_result.get("content", {}).get("text", "")
             source = extract_source_from_retrieval_result(retrieval_result)
-            
+
             search_results.append(
-                SearchResult(
-                    rank=i,
-                    bot_id=bot.id,
-                    content=content,
-                    source=source
-                )
+                SearchResult(rank=i, bot_id=bot.id, content=content, source=source)
             )
-        
 
         return search_results
 

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -71,8 +71,6 @@ def get_source_link(source: str) -> tuple[Literal["s3", "url"], str]:
             client_method="get_object",
         )
         return "s3", source_link
-    elif source.startswith("http://") or source.startswith("https://"):
-        return "url", source
     else:
         # Return the source as is for knowledge base references
         return "url", source

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -78,6 +78,7 @@ class TestCustomBotRepository(unittest.TestCase):
                     overlap_percentage=0,
                 ),
                 parsing_model="anthropic.claude-3-sonnet-v1",
+                web_crawling_scope="DEFAULT",
             ),
             bedrock_guardrails=BedrockGuardrailsModel(
                 is_guardrail_enabled=True,

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -77,6 +77,7 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_tokens=2000,
                     overlap_percentage=0,
                 ),
+                parsing_model="anthropic.claude-3-sonnet-v1"
             ),
             bedrock_guardrails=BedrockGuardrailsModel(
                 is_guardrail_enabled=True,

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -77,7 +77,7 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_tokens=2000,
                     overlap_percentage=0,
                 ),
-                parsing_model="anthropic.claude-3-sonnet-v1"
+                parsing_model="anthropic.claude-3-sonnet-v1",
             ),
             bedrock_guardrails=BedrockGuardrailsModel(
                 is_guardrail_enabled=True,

--- a/cdk/bin/bedrock-custom-bot.ts
+++ b/cdk/bin/bedrock-custom-bot.ts
@@ -5,6 +5,7 @@ import {
   getEmbeddingModel,
   getChunkingStrategy,
   getAnalyzer,
+  getParsingModel,
 } from "../lib/utils/bedrock-knowledge-base-args";
 
 const app = new cdk.App();
@@ -49,7 +50,7 @@ console.log("guardrails: ", guardrails);
 console.log("existingS3Urls: ", existingS3Urls);
 
 const embeddingsModel = getEmbeddingModel(knowledgeBase.embeddings_model.S);
-
+const parsingModel = getParsingModel(knowledgeBase.parsing_model.S)
 const maxTokens: number | undefined = knowledgeBase.chunking_configuration.M.max_tokens
   ? Number(knowledgeBase.chunking_configuration.M.max_tokens.N)
   : undefined;
@@ -135,6 +136,7 @@ console.log("misconductThreshold: ", misconductThreshold);
 console.log("relevanceThreshold: ", relevanceThreshold);
 console.log("guardrailArn: ", guardrailArn);
 console.log("guardrailVersion: ", guardrailVersion);
+console.log("parsingModel: ", parsingModel);
 
 if (analyzer) {
   console.log(
@@ -158,6 +160,7 @@ const bedrockCustomBotStack = new BedrockCustomBotStack(
     ownerUserId,
     botId,
     embeddingsModel,
+    parsingModel,
     bedrockClaudeChatDocumentBucketName:
       BEDROCK_CLAUDE_CHAT_DOCUMENT_BUCKET_NAME,
     chunkingStrategy,

--- a/cdk/bin/bedrock-custom-bot.ts
+++ b/cdk/bin/bedrock-custom-bot.ts
@@ -6,7 +6,12 @@ import {
   getChunkingStrategy,
   getAnalyzer,
   getParsingModel,
+  getCrowlingScope,
+  getCrawlingFilters,
 } from "../lib/utils/bedrock-knowledge-base-args";
+import {
+  CrawlingFilters,
+} from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/web-crawler-data-source";
 
 const app = new cdk.App();
 
@@ -40,6 +45,9 @@ const guardrails = JSON.parse(BEDROCK_GUARDRAILS);
 const existingS3Urls: string[] = knowledge.s3_urls.L.map(
   (s3Url: any) => s3Url.S
 );
+const sourceUrls: string[] = knowledge.source_urls.L.map(
+  (sourceUrl: any) => sourceUrl.S
+);
 const useStandbyReplicas: boolean = USE_STAND_BY_REPLICAS === "true";
 
 console.log("ownerUserId: ", ownerUserId);
@@ -48,9 +56,12 @@ console.log("knowledgeBase: ", knowledgeBase);
 console.log("knowledge: ", knowledge);
 console.log("guardrails: ", guardrails);
 console.log("existingS3Urls: ", existingS3Urls);
+console.log("sourceUrls: ", sourceUrls);
 
 const embeddingsModel = getEmbeddingModel(knowledgeBase.embeddings_model.S);
 const parsingModel = getParsingModel(knowledgeBase.parsing_model.S)
+const crawlingScope = getCrowlingScope(knowledgeBase.web_crawling_scope.S)
+const crawlingFilters: CrawlingFilters = getCrawlingFilters(knowledgeBase.web_crawling_filters.M)
 const maxTokens: number | undefined = knowledgeBase.chunking_configuration.M.max_tokens
   ? Number(knowledgeBase.chunking_configuration.M.max_tokens.N)
   : undefined;
@@ -137,6 +148,7 @@ console.log("relevanceThreshold: ", relevanceThreshold);
 console.log("guardrailArn: ", guardrailArn);
 console.log("guardrailVersion: ", guardrailVersion);
 console.log("parsingModel: ", parsingModel);
+console.log("crawlingScope: ", crawlingScope);
 
 if (analyzer) {
   console.log(
@@ -161,10 +173,13 @@ const bedrockCustomBotStack = new BedrockCustomBotStack(
     botId,
     embeddingsModel,
     parsingModel,
+    crawlingScope,
+    crawlingFilters,
     bedrockClaudeChatDocumentBucketName:
       BEDROCK_CLAUDE_CHAT_DOCUMENT_BUCKET_NAME,
     chunkingStrategy,
     existingS3Urls,
+    sourceUrls,
     maxTokens,
     instruction,
     analyzer,

--- a/cdk/lib/bedrock-custom-bot-stack.ts
+++ b/cdk/lib/bedrock-custom-bot-stack.ts
@@ -16,6 +16,10 @@ import {
 import {
   S3DataSource,
 } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/s3-data-source";
+import {
+  ParsingStategy
+} from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/parsing";
+
 import { KnowledgeBase } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock";
 import { aws_bedrock as bedrock } from "aws-cdk-lib";
 
@@ -41,6 +45,7 @@ interface BedrockCustomBotStackProps extends StackProps {
   readonly ownerUserId: string;
   readonly botId: string;
   readonly embeddingsModel: BedrockFoundationModel;
+  readonly parsingModel?: BedrockFoundationModel;
   readonly bedrockClaudeChatDocumentBucketName: string;
   readonly chunkingStrategy: ChunkingStrategy;
   readonly existingS3Urls: string[];
@@ -102,6 +107,9 @@ export class BedrockCustomBotStack extends Stack {
         knowledgeBase: kb,
         dataSourceName: bucket.bucketName,
         chunkingStrategy: props.chunkingStrategy,
+        parsingStrategy: props.parsingModel ? ParsingStategy.foundationModel({
+          parsingModel: props.parsingModel.asIModel(this),
+        }) : undefined,
         inclusionPrefixes: inclusionPrefixes,
       });
     });

--- a/cdk/lib/bedrock-custom-bot-stack.ts
+++ b/cdk/lib/bedrock-custom-bot-stack.ts
@@ -139,7 +139,7 @@ export class BedrockCustomBotStack extends Stack {
         }
 
       });
-      new CfnOutput(this, 'webCrawlerDataSourceId', {
+      new CfnOutput(this, 'DataSourceIdWebCrawler', {
         value: webCrawlerDataSource.dataSourceId
       })
     }

--- a/cdk/lib/bedrock-custom-bot-stack.ts
+++ b/cdk/lib/bedrock-custom-bot-stack.ts
@@ -123,10 +123,9 @@ export class BedrockCustomBotStack extends Stack {
     });
 
     // Add Web Crawler Data Sources
-    if (props.sourceUrls && props.sourceUrls.length > 0) {
+    if (props.sourceUrls.length > 0) {
       const webCrawlerDataSource = new WebCrawlerDataSource(this, 'WebCrawlerDataSource', {
         knowledgeBase: kb,
-        dataSourceName: 'webcrawler',
         sourceUrls: props.sourceUrls,
         chunkingStrategy: props.chunkingStrategy,
         parsingStrategy: props.parsingModel ? ParsingStategy.foundationModel({

--- a/cdk/lib/bedrock-custom-bot-stack.ts
+++ b/cdk/lib/bedrock-custom-bot-stack.ts
@@ -17,6 +17,11 @@ import {
   S3DataSource,
 } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/s3-data-source";
 import {
+  WebCrawlerDataSource,
+  CrawlingScope,
+  CrawlingFilters,
+} from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/web-crawler-data-source";
+import {
   ParsingStategy
 } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/parsing";
 
@@ -49,12 +54,15 @@ interface BedrockCustomBotStackProps extends StackProps {
   readonly bedrockClaudeChatDocumentBucketName: string;
   readonly chunkingStrategy: ChunkingStrategy;
   readonly existingS3Urls: string[];
+  readonly sourceUrls: string[];
   readonly maxTokens?: number;
   readonly instruction?: string;
   readonly analyzer?: Analyzer;
   readonly overlapPercentage?: number;
   readonly guardrail?: BedrockGuardrailProps;
   readonly useStandbyReplicas?: boolean;
+  readonly crawlingScope?: CrawlingScope;
+  readonly crawlingFilters?: CrawlingFilters;
 }
 
 export class BedrockCustomBotStack extends Stack {
@@ -113,6 +121,28 @@ export class BedrockCustomBotStack extends Stack {
         inclusionPrefixes: inclusionPrefixes,
       });
     });
+
+    // Add Web Crawler Data Sources
+    if (props.sourceUrls && props.sourceUrls.length > 0) {
+      const webCrawlerDataSource = new WebCrawlerDataSource(this, 'WebCrawlerDataSource', {
+        knowledgeBase: kb,
+        dataSourceName: 'webcrawler',
+        sourceUrls: props.sourceUrls,
+        chunkingStrategy: props.chunkingStrategy,
+        parsingStrategy: props.parsingModel ? ParsingStategy.foundationModel({
+          parsingModel: props.parsingModel.asIModel(this),
+        }) : undefined,
+        crawlingScope: props.crawlingScope,
+        filters: {
+          excludePatterns: props.crawlingFilters?.excludePatterns,
+          includePatterns: props.crawlingFilters?.includePatterns,
+        }
+
+      });
+      new CfnOutput(this, 'webCrawlerDataSourceId', {
+        value: webCrawlerDataSource.dataSourceId
+      })
+    }
 
     if (props.guardrail?.is_guardrail_enabled == true) {
       // Use only parameters with a value greater than or equal to 0

--- a/cdk/lib/bedrock-custom-bot-stack.ts
+++ b/cdk/lib/bedrock-custom-bot-stack.ts
@@ -51,7 +51,6 @@ interface BedrockCustomBotStackProps extends StackProps {
   readonly botId: string;
   readonly embeddingsModel: BedrockFoundationModel;
   readonly parsingModel?: BedrockFoundationModel;
-  readonly parsingModel?: BedrockFoundationModel;
   readonly bedrockClaudeChatDocumentBucketName: string;
   readonly chunkingStrategy: ChunkingStrategy;
   readonly existingS3Urls: string[];
@@ -116,9 +115,6 @@ export class BedrockCustomBotStack extends Stack {
         knowledgeBase: kb,
         dataSourceName: bucket.bucketName,
         chunkingStrategy: props.chunkingStrategy,
-        parsingStrategy: props.parsingModel ? ParsingStategy.foundationModel({
-          parsingModel: props.parsingModel.asIModel(this),
-        }) : undefined,
         parsingStrategy: props.parsingModel ? ParsingStategy.foundationModel({
           parsingModel: props.parsingModel.asIModel(this),
         }) : undefined,

--- a/cdk/lib/utils/bedrock-knowledge-base-args.ts
+++ b/cdk/lib/utils/bedrock-knowledge-base-args.ts
@@ -1,3 +1,4 @@
+import { unmarshall } from "@aws-sdk/util-dynamodb";
 import {
   BedrockFoundationModel,
 } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock";
@@ -5,6 +6,10 @@ import {
   HierarchicalChunkingProps,
   ChunkingStrategy,
 } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/chunking";
+import {
+  CrawlingScope,
+  CrawlingFilters,
+} from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/bedrock/data-sources/web-crawler-data-source";
 import { Analyzer } from "@cdklabs/generative-ai-cdk-constructs/lib/cdk-lib/opensearch-vectorindex";
 import {
   CharacterFilterType,
@@ -48,6 +53,40 @@ export const getParsingModel = (
       return undefined
     default:
       throw new Error(`Unknown parsing model: ${parsingModel}`);
+  }
+}
+
+export const getCrowlingScope = (
+  web_crawling_scope: string
+): CrawlingScope | undefined => {
+
+  switch(web_crawling_scope) {
+    case "DEFAULT":
+      return CrawlingScope.DEFAULT
+    case "HOST_ONLY":
+      return CrawlingScope.HOST_ONLY
+    case "SUBDOMAINS":
+      return CrawlingScope.SUBDOMAINS
+    default:
+      return undefined
+  }
+}
+
+export const getCrawlingFilters =(
+  web_crawling_filters: any
+): CrawlingFilters => {
+  const regularJson = unmarshall(web_crawling_filters);
+  console.log(`regularJson: ${JSON.stringify(regularJson)}`)
+
+  let excludePatterns = undefined
+  let includePatterns = undefined
+
+  if (regularJson.exclude_patterns.length > 0 && regularJson.exclude_patterns[0] != "") excludePatterns = regularJson.exclude_patterns
+  if (regularJson.include_patterns.length > 0 && regularJson.include_patterns[0] != "") includePatterns = regularJson.include_patterns
+
+  return {
+    excludePatterns,
+    includePatterns,
   }
 }
 

--- a/cdk/lib/utils/bedrock-knowledge-base-args.ts
+++ b/cdk/lib/utils/bedrock-knowledge-base-args.ts
@@ -36,6 +36,21 @@ export const getEmbeddingModel = (
   }
 };
 
+export const getParsingModel = (
+  parsingModel: string
+): BedrockFoundationModel | undefined => {
+  switch (parsingModel) {
+    case "anthropic.claude-3-sonnet-v1":
+      return BedrockFoundationModel.ANTHROPIC_CLAUDE_SONNET_V1_0;
+    case "anthropic.claude-3-haiku-v1":
+      return BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0;
+    case "disabled":
+      return undefined
+    default:
+      throw new Error(`Unknown parsing model: ${parsingModel}`);
+  }
+}
+
 export const getChunkingStrategy = (
   chunkingStrategy: string,
   embeddingsModel: string,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@aws-cdk/aws-glue-alpha": "^2.155.0-alpha.0",
         "@aws-cdk/aws-lambda-python-alpha": "^2.155.0-alpha.0",
+        "@aws-sdk/util-dynamodb": "^3.693.0",
         "@cdklabs/generative-ai-cdk-constructs": "^0.1.274",
-        "aws-cdk-lib": "^2.155.0",
+        "aws-cdk-lib": "^2.162.1",
         "cdk-aws-lambda-powertools-layer": "^3.7.0",
         "constructs": "^10.0.0",
         "deploy-time-build": "^0.3.2",
@@ -25,7 +26,7 @@
         "@aws-prototyping-sdk/pdk-nag": "^0.19.68",
         "@types/jest": "^29.5.3",
         "@types/node": "20.4.2",
-        "aws-cdk": "^2.162.1",
+        "aws-cdk": "2.162.1",
         "jest": "^29.6.1",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
@@ -116,6 +117,141 @@
         "node": ">=10"
       }
     },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-prototyping-sdk/pdk-nag": {
       "version": "0.19.68",
       "resolved": "https://registry.npmjs.org/@aws-prototyping-sdk/pdk-nag/-/pdk-nag-0.19.68.tgz",
@@ -126,6 +262,622 @@
         "aws-cdk-lib": "^2.81.0",
         "cdk-nag": "^2.27.24",
         "constructs": "^10.2.39"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.693.0.tgz",
+      "integrity": "sha512-EmgFoE/wAxiOq/sfO/VFGlmvfq0FexUO4IMURr3deIpU/AuCsuU87HJH/UodFdKu88ykNZxMfHHku6o6BV2dAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.693.0",
+        "@aws-sdk/client-sts": "3.693.0",
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/credential-provider-node": "3.693.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.693.0",
+        "@aws-sdk/middleware-host-header": "3.693.0",
+        "@aws-sdk/middleware-logger": "3.693.0",
+        "@aws-sdk/middleware-recursion-detection": "3.693.0",
+        "@aws-sdk/middleware-user-agent": "3.693.0",
+        "@aws-sdk/region-config-resolver": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@aws-sdk/util-endpoints": "3.693.0",
+        "@aws-sdk/util-user-agent-browser": "3.693.0",
+        "@aws-sdk/util-user-agent-node": "3.693.0",
+        "@smithy/config-resolver": "^3.0.11",
+        "@smithy/core": "^2.5.2",
+        "@smithy/fetch-http-handler": "^4.1.0",
+        "@smithy/hash-node": "^3.0.9",
+        "@smithy/invalid-dependency": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.2.2",
+        "@smithy/middleware-retry": "^3.0.26",
+        "@smithy/middleware-serde": "^3.0.9",
+        "@smithy/middleware-stack": "^3.0.9",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/node-http-handler": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/url-parser": "^3.0.9",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.26",
+        "@smithy/util-defaults-mode-node": "^3.0.26",
+        "@smithy/util-endpoints": "^2.1.5",
+        "@smithy/util-middleware": "^3.0.9",
+        "@smithy/util-retry": "^3.0.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.8",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.693.0.tgz",
+      "integrity": "sha512-QEynrBC26x6TG9ZMzApR/kZ3lmt4lEIs2D+cHuDxt6fDGzahBUsQFBwJqhizzsM97JJI5YvmJhmihoYjdSSaXA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/middleware-host-header": "3.693.0",
+        "@aws-sdk/middleware-logger": "3.693.0",
+        "@aws-sdk/middleware-recursion-detection": "3.693.0",
+        "@aws-sdk/middleware-user-agent": "3.693.0",
+        "@aws-sdk/region-config-resolver": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@aws-sdk/util-endpoints": "3.693.0",
+        "@aws-sdk/util-user-agent-browser": "3.693.0",
+        "@aws-sdk/util-user-agent-node": "3.693.0",
+        "@smithy/config-resolver": "^3.0.11",
+        "@smithy/core": "^2.5.2",
+        "@smithy/fetch-http-handler": "^4.1.0",
+        "@smithy/hash-node": "^3.0.9",
+        "@smithy/invalid-dependency": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.2.2",
+        "@smithy/middleware-retry": "^3.0.26",
+        "@smithy/middleware-serde": "^3.0.9",
+        "@smithy/middleware-stack": "^3.0.9",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/node-http-handler": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/url-parser": "^3.0.9",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.26",
+        "@smithy/util-defaults-mode-node": "^3.0.26",
+        "@smithy/util-endpoints": "^2.1.5",
+        "@smithy/util-middleware": "^3.0.9",
+        "@smithy/util-retry": "^3.0.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.693.0.tgz",
+      "integrity": "sha512-UEDbYlYtK/e86OOMyFR4zEPyenIxDzO2DRdz3fwVW7RzZ94wfmSwBh/8skzPTuY1G7sI064cjHW0b0QG01Sdtg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/credential-provider-node": "3.693.0",
+        "@aws-sdk/middleware-host-header": "3.693.0",
+        "@aws-sdk/middleware-logger": "3.693.0",
+        "@aws-sdk/middleware-recursion-detection": "3.693.0",
+        "@aws-sdk/middleware-user-agent": "3.693.0",
+        "@aws-sdk/region-config-resolver": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@aws-sdk/util-endpoints": "3.693.0",
+        "@aws-sdk/util-user-agent-browser": "3.693.0",
+        "@aws-sdk/util-user-agent-node": "3.693.0",
+        "@smithy/config-resolver": "^3.0.11",
+        "@smithy/core": "^2.5.2",
+        "@smithy/fetch-http-handler": "^4.1.0",
+        "@smithy/hash-node": "^3.0.9",
+        "@smithy/invalid-dependency": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.2.2",
+        "@smithy/middleware-retry": "^3.0.26",
+        "@smithy/middleware-serde": "^3.0.9",
+        "@smithy/middleware-stack": "^3.0.9",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/node-http-handler": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/url-parser": "^3.0.9",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.26",
+        "@smithy/util-defaults-mode-node": "^3.0.26",
+        "@smithy/util-endpoints": "^2.1.5",
+        "@smithy/util-middleware": "^3.0.9",
+        "@smithy/util-retry": "^3.0.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.693.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.693.0.tgz",
+      "integrity": "sha512-4S2y7VEtvdnjJX4JPl4kDQlslxXEZFnC50/UXVUYSt/AMc5A/GgspFNA5FVz4E3Gwpfobbf23hR2NBF8AGvYoQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.693.0",
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/credential-provider-node": "3.693.0",
+        "@aws-sdk/middleware-host-header": "3.693.0",
+        "@aws-sdk/middleware-logger": "3.693.0",
+        "@aws-sdk/middleware-recursion-detection": "3.693.0",
+        "@aws-sdk/middleware-user-agent": "3.693.0",
+        "@aws-sdk/region-config-resolver": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@aws-sdk/util-endpoints": "3.693.0",
+        "@aws-sdk/util-user-agent-browser": "3.693.0",
+        "@aws-sdk/util-user-agent-node": "3.693.0",
+        "@smithy/config-resolver": "^3.0.11",
+        "@smithy/core": "^2.5.2",
+        "@smithy/fetch-http-handler": "^4.1.0",
+        "@smithy/hash-node": "^3.0.9",
+        "@smithy/invalid-dependency": "^3.0.9",
+        "@smithy/middleware-content-length": "^3.0.11",
+        "@smithy/middleware-endpoint": "^3.2.2",
+        "@smithy/middleware-retry": "^3.0.26",
+        "@smithy/middleware-serde": "^3.0.9",
+        "@smithy/middleware-stack": "^3.0.9",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/node-http-handler": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/url-parser": "^3.0.9",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.26",
+        "@smithy/util-defaults-mode-node": "^3.0.26",
+        "@smithy/util-endpoints": "^2.1.5",
+        "@smithy/util-middleware": "^3.0.9",
+        "@smithy/util-retry": "^3.0.9",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.693.0.tgz",
+      "integrity": "sha512-v6Z/kWmLFqRLDPEwl9hJGhtTgIFHjZugSfF1Yqffdxf4n1AWgtHS7qSegakuMyN5pP4K2tvUD8qHJ+gGe2Bw2A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/core": "^2.5.2",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/util-middleware": "^3.0.9",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.693.0.tgz",
+      "integrity": "sha512-hMUZaRSF7+iBKZfBHNLihFs9zvpM1CB8MBOTnTp5NGCVkRYF3SB2LH+Kcippe0ats4qCyB1eEoyQX99rERp2iQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.693.0.tgz",
+      "integrity": "sha512-sL8MvwNJU7ZpD7/d2VVb3by1GknIJUxzTIgYtVkDVA/ojo+KRQSSHxcj0EWWXF5DTSh2Tm+LrEug3y1ZyKHsDA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/fetch-http-handler": "^4.1.0",
+        "@smithy/node-http-handler": "^3.3.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/smithy-client": "^3.4.3",
+        "@smithy/types": "^3.7.0",
+        "@smithy/util-stream": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.693.0.tgz",
+      "integrity": "sha512-kvaa4mXhCCOuW7UQnBhYqYfgWmwy7WSBSDClutwSLPZvgrhYj2l16SD2lN4IfYdxARYMJJ1lFYp3/jJG/9Yk4Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/credential-provider-env": "3.693.0",
+        "@aws-sdk/credential-provider-http": "3.693.0",
+        "@aws-sdk/credential-provider-process": "3.693.0",
+        "@aws-sdk/credential-provider-sso": "3.693.0",
+        "@aws-sdk/credential-provider-web-identity": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.693.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.693.0.tgz",
+      "integrity": "sha512-42WMsBjTNnjYxYuM3qD/Nq+8b7UdMopUq5OduMDxoM3mFTV6PXMMnfI4Z1TNnR4tYRvPXAnuNltF6xmjKbSJRA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.693.0",
+        "@aws-sdk/credential-provider-http": "3.693.0",
+        "@aws-sdk/credential-provider-ini": "3.693.0",
+        "@aws-sdk/credential-provider-process": "3.693.0",
+        "@aws-sdk/credential-provider-sso": "3.693.0",
+        "@aws-sdk/credential-provider-web-identity": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.693.0.tgz",
+      "integrity": "sha512-cvxQkrTWHHjeHrPlj7EWXPnFSq8x7vMx+Zn1oTsMpCY445N9KuzjfJTkmNGwU2GT6rSZI9/0MM02aQvl5bBBTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.693.0.tgz",
+      "integrity": "sha512-479UlJxY+BFjj3pJFYUNC0DCMrykuG7wBAXfsvZqQxKUa83DnH5Q1ID/N2hZLkxjGd4ZW0AC3lTOMxFelGzzpQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.693.0",
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/token-providers": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.693.0.tgz",
+      "integrity": "sha512-8LB210Pr6VeCiSb2hIra+sAH4KUBLyGaN50axHtIgufVK8jbKIctTZcVY5TO9Se+1107TsruzeXS7VeqVdJfFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.693.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.693.0.tgz",
+      "integrity": "sha512-/zK0ZZncBf5FbTfo8rJMcQIXXk4Ibhe5zEMiwFNivVPR2uNC0+oqfwXz7vjxwY0t6BPE3Bs4h9uFEz4xuGCY6w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.693.0.tgz",
+      "integrity": "sha512-OG8WM8OzYuAt3Ueb8TZoBgA+vqNgPaXksHhiy8SFTQxNamSMMRvKrDSBbdUuV96mq0lcJq1mFgJ4oRXJ1HPh6A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.693.0.tgz",
+      "integrity": "sha512-BCki6sAZ5jYwIN/t3ElCiwerHad69ipHwPsDCxJQyeiOnJ8HG+lEpnVIfrnI8A0fLQNSF3Gtx6ahfBpKiv1Oug==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.693.0.tgz",
+      "integrity": "sha512-dXnXDPr+wIiJ1TLADACI1g9pkSB21KkMIko2u4CJ2JCBoxi5IqeTnVoa6YcC8GdFNVRl+PorZ3Zqfmf1EOTC6w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.693.0.tgz",
+      "integrity": "sha512-0LDmM+VxXp0u3rG0xQRWD/q6Ubi7G8I44tBPahevD5CaiDZTkmNTrVUf0VEJgVe0iCKBppACMBDkLB0/ETqkFw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.693.0.tgz",
+      "integrity": "sha512-/KUq/KEpFFbQmNmpp7SpAtFAdViquDfD2W0QcG07zYBfz9MwE2ig48ALynXm5sMpRmnG7sJXjdvPtTsSVPfkiw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@aws-sdk/util-endpoints": "3.693.0",
+        "@smithy/core": "^2.5.2",
+        "@smithy/protocol-http": "^4.1.6",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.693.0.tgz",
+      "integrity": "sha512-YLUkMsUY0GLW/nfwlZ69cy1u07EZRmsv8Z9m0qW317/EZaVx59hcvmcvb+W4bFqj5E8YImTjoGfE4cZ0F9mkyw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.693.0.tgz",
+      "integrity": "sha512-nDBTJMk1l/YmFULGfRbToOA2wjf+FkQT4dMgYCv+V9uSYsMzQj8A7Tha2dz9yv4vnQgYaEiErQ8d7HVyXcVEoA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.693.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.692.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.692.0.tgz",
+      "integrity": "sha512-RpNvzD7zMEhiKgmlxGzyXaEcg2khvM7wd5sSHVapOcrde1awQSOMGI4zKBQ+wy5TnDfrm170ROz/ERLYtrjPZA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.693.0.tgz",
+      "integrity": "sha512-lwJnlQndVS7cGN1UmtG4s6IdVW3U/WheJ14Xc/mUeAH3vga7GTY3hGi+Jp1TbnaYQkad589tU+NQ5KUW7V8ZjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.693.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.693.0.tgz",
+      "integrity": "sha512-eo4F6DRQ/kxS3gxJpLRv+aDNy76DxQJL5B3DPzpr9Vkq0ygVoi4GT5oIZLVaAVIJmi6k5qq9dLsYZfWLUxJJSg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/types": "^3.7.0",
+        "@smithy/util-endpoints": "^2.1.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.693.0.tgz",
+      "integrity": "sha512-ttrag6haJLWABhLqtg1Uf+4LgHWIMOVSYL+VYZmAp2v4PUGOwWmWQH0Zk8RM7YuQcLfH/EoR72/Yxz6A4FKcuw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.693.0.tgz",
+      "integrity": "sha512-6EUfuKOujtddy18OLJUaXfKBgs+UcbZ6N/3QV4iOkubCUdeM1maIqs++B9bhCbWeaeF5ORizJw5FTwnyNjE/mw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/types": "^3.7.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.693.0.tgz",
+      "integrity": "sha512-td0OVX8m5ZKiXtecIDuzY3Y3UZIzvxEr57Hp21NOwieqKCG2UeyQWWeGPv0FQaU7dpTkvFmVNI+tx9iB8V/Nhg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.693.0",
+        "@aws-sdk/types": "3.692.0",
+        "@smithy/node-config-provider": "^3.1.10",
+        "@smithy/types": "^3.7.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1189,6 +1941,613 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
+      "integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
+      "integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-96uW8maifUSmehaeW7uydWn7wBc98NEeNI3zN8vqakGpyCQgzyJaA64Z4FCOUmAdCJkhppd/7SZ798Fo4Xx37g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
+      "integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
+      "integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
+      "integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
+      "integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.3.tgz",
+      "integrity": "sha512-Hdl9296i/EMptaX7agrSzJZDiz5Y8XPUeBbctTmMtnCguGpqfU3jVsTUan0VLaOhsnquqWLL8Bl5HrlbVGT1og==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.3",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.27.tgz",
+      "integrity": "sha512-H3J/PjJpLL7Tt+fxDKiOD25sMc94YetlQhCnYeNmina2LZscAdu0ZEZPas/kwePHABaEtqp7hqa5S4UJgMs1Tg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
+      "integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
+      "integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
+      "integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
+      "integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
+      "integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
+      "integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
+      "integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
+      "integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
+      "integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
+      "integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
+      "integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.4.tgz",
+      "integrity": "sha512-dPGoJuSZqvirBq+yROapBcHHvFjChoAQT8YPWJ820aPHHiowBlB3RL1Q4kPT1hx0qKgJuf+HhyzKi5Gbof4fNA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.3",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
+      "integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.27.tgz",
+      "integrity": "sha512-GV8NvPy1vAGp7u5iD/xNKUxCorE4nQzlyl057qRac+KwpH5zq8wVq6rE3lPPeuFLyQXofPN6JwxL1N9ojGapiQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.27.tgz",
+      "integrity": "sha512-7+4wjWfZqZxZVJvDutO+i1GvL6bgOajEkop4FuR6wudFlqBiqwxw3HoH6M9NgeCd37km8ga8NPp2JacQEtAMPg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/credential-provider-imds": "^3.2.7",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
+      "integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
+      "integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
+      "integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
+      "integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.9.tgz",
+      "integrity": "sha512-/aMXPANhMOlMPjfPtSrDfPeVP8l56SJlz93xeiLmhLe5xvlXA5T3abZ2ilEsDEPeY9T/wnN/vNGn9wa1SbufWA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.8",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -1314,6 +2673,13 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -1870,6 +3236,13 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2334,6 +3707,29 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3447,6 +4843,16 @@
         "node": "*"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3491,6 +4897,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -3929,6 +5342,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4113,6 +5533,12 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4175,6 +5601,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "^2.155.0-alpha.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.155.0-alpha.0",
+    "@aws-sdk/util-dynamodb": "^3.693.0",
     "@cdklabs/generative-ai-cdk-constructs": "^0.1.274",
     "aws-cdk-lib": "^2.162.1",
     "cdk-aws-lambda-powertools-layer": "^3.7.0",

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -319,6 +319,9 @@ describe("Bedrock Knowledge Base Stack", () => {
       instruction,
       analyzer,
       overlapPercentage,
+      sourceUrls: knowledge.source_urls.L.map(
+        (sourceUrl: any) => sourceUrl.S
+      )
     });
 
     return Template.fromStack(stack);

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -14,6 +14,7 @@ import KnowledgeFileUploader from '../../../components/KnowledgeFileUploader';
 import GenerationConfig from '../../../components/GenerationConfig';
 import Select from '../../../components/Select';
 import { BotFile, ConversationQuickStarter } from '../../../@types/bot';
+import { ParsingModel } from '../types';
 
 import { ulid } from 'ulid';
 import {
@@ -121,6 +122,7 @@ const BotKbEditPage: React.FC = () => {
   const [relevanceThreshold, setRelevanceThreshold] = useState<number>(0);
   const [guardrailArn, setGuardrailArn] = useState<string>('');
   const [guardrailVersion, setGuardrailVersion] = useState<string>('');
+  const [parsingModel, setParsingModel] = useState<ParsingModel | undefined>(undefined);
 
   const embeddingsModelOptions: {
     label: string;
@@ -172,6 +174,28 @@ const BotKbEditPage: React.FC = () => {
         description: t('knowledgeBaseSettings.chunkingStrategy.none.hint'),
       },
     ];
+  
+  const parsingModelOptions: {
+    label: string;
+    value: ParsingModel;
+    description: string;
+  }[] = [
+    {
+      label: t('knowledgeBaseSettings.parsingModel.none.label'),
+      value: 'disabled',
+      description: t('knowledgeBaseSettings.parsingModel.none.hint'),
+    },
+    {
+      label: t('knowledgeBaseSettings.parsingModel.claude_3_sonnet.label'),
+      value: 'anthropic.claude-3-sonnet-v1',
+      description: t('knowledgeBaseSettings.parsingModel.claude_3_sonnet.hint'),
+    },
+    {
+      label: t('knowledgeBaseSettings.parsingModel.claude_3_haiku.label'),
+      value: 'anthropic.claude-3-haiku-v1',
+      description: t('knowledgeBaseSettings.parsingModel.claude_3_haiku.hint'),
+    },
+  ];
 
   const [fixedSizeParams, setFixedSizeParams] = useState<FixedSizeParams>(
     DEFAULT_FIXED_CHUNK_PARAMS
@@ -366,6 +390,7 @@ const BotKbEditPage: React.FC = () => {
               ? bot.bedrockGuardrails.relevanceThreshold
               : 0
           );
+          setParsingModel(bot.bedrockKnowledgeBase.parsingModel);
         })
         .finally(() => {
           setIsLoading(false);
@@ -881,6 +906,7 @@ const BotKbEditPage: React.FC = () => {
         })(),
         openSearch: openSearchParams,
         searchParams: searchParams,
+        parsingModel,
       },
       bedrockGuardrails: {
         isGuardrailEnabled:
@@ -942,6 +968,7 @@ const BotKbEditPage: React.FC = () => {
     misconductThreshold,
     groundingThreshold,
     relevanceThreshold,
+    parsingModel,
   ]);
 
   const onClickEdit = useCallback(() => {
@@ -996,6 +1023,7 @@ const BotKbEditPage: React.FC = () => {
           })(),
           openSearch: openSearchParams,
           searchParams: searchParams,
+          parsingModel,
         },
         bedrockGuardrails: {
           isGuardrailEnabled:
@@ -1063,6 +1091,7 @@ const BotKbEditPage: React.FC = () => {
     relevanceThreshold,
     guardrailArn,
     guardrailVersion,
+    parsingModel,
   ]);
 
   const [isOpenSamples, setIsOpenSamples] = useState(false);
@@ -1351,6 +1380,18 @@ const BotKbEditPage: React.FC = () => {
                     options={embeddingsModelOptions}
                     onChange={(val) => {
                       onChangeEmbeddingsModel(val as EmbeddingsModel);
+                    }}
+                    disabled={!isNewBot}
+                  />
+                </div>
+
+                <div className="mt-3">
+                  <Select
+                    label={t('bot.label.selectParsingModel')}
+                    value={parsingModel || 'disabled'}
+                    options={parsingModelOptions}
+                    onChange={(val) => {
+                      setParsingModel(val as ParsingModel);
                     }}
                     disabled={!isNewBot}
                   />

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -57,6 +57,7 @@ import {
   OpenSearchParams,
   SearchParams,
   SearchType,
+  WebCrawlingScope,
 } from '../types';
 
 const edgeGenerationParams =
@@ -108,6 +109,7 @@ const BotKbEditPage: React.FC = () => {
       example: '',
     },
   ]);
+  const [webCrawlingScope, setWebCrawlingScope] = useState<WebCrawlingScope>('DEFAULT');
 
   const [knowledgeBaseId, setKnowledgeBaseId] = useState<string | null>(null); // Send null when creating a new bot
   const [embeddingsModel, setEmbeddingsModel] =
@@ -123,6 +125,13 @@ const BotKbEditPage: React.FC = () => {
   const [guardrailArn, setGuardrailArn] = useState<string>('');
   const [guardrailVersion, setGuardrailVersion] = useState<string>('');
   const [parsingModel, setParsingModel] = useState<ParsingModel | undefined>(undefined);
+  const [webCrawlingFilters, setWebCrawlingFilters] = useState<{
+    includePatterns: string[];
+    excludePatterns: string[];
+  }>({
+    includePatterns: [''],
+    excludePatterns: [''],
+  });
 
   const embeddingsModelOptions: {
     label: string;
@@ -142,6 +151,28 @@ const BotKbEditPage: React.FC = () => {
 
   const [chunkingStrategy, setChunkingStrategy] =
     useState<ChunkingStrategy>('default');
+
+  const webCrawlingScopeOptions: {
+    label: string;
+    value: WebCrawlingScope;
+    description: string;
+  }[] = [
+    {
+      label: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.default.label'),
+      value: 'DEFAULT',
+      description: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.default.hint'),
+    },
+    {
+      label: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.subdomains.label'),
+      value: 'SUBDOMAINS',
+      description: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.subdomains.hint'),
+    },
+    {
+      label: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.hostOnly.label'),
+      value: 'HOST_ONLY',
+      description: t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.hostOnly.hint'),
+    },
+  ];
 
   const chunkingStrategyOptions: {
     label: string;
@@ -282,6 +313,72 @@ const BotKbEditPage: React.FC = () => {
     return isNewBot ? ulid() : (paramsBotId ?? '');
   }, [isNewBot, paramsBotId]);
 
+  const onChangeIncludePattern = useCallback(
+    (pattern: string, idx: number) => {
+      setWebCrawlingFilters(
+        produce(webCrawlingFilters, (draft) => {
+          draft.includePatterns[idx] = pattern;
+        })
+      );
+    },
+    [webCrawlingFilters]
+  );
+
+  const onClickAddIncludePattern = useCallback(() => {
+    setWebCrawlingFilters(
+      produce(webCrawlingFilters, (draft) => {
+        draft.includePatterns.push('');
+      })
+    );
+  }, [webCrawlingFilters]);
+
+  const onClickRemoveIncludePattern = useCallback(
+    (idx: number) => {
+      setWebCrawlingFilters(
+        produce(webCrawlingFilters, (draft) => {
+          draft.includePatterns.splice(idx, 1);
+          if (draft.includePatterns.length === 0) {
+            draft.includePatterns.push('');
+          }
+        })
+      );
+    },
+    [webCrawlingFilters]
+  );
+
+  const onChangeExcludePattern = useCallback(
+    (pattern: string, idx: number) => {
+      setWebCrawlingFilters(
+        produce(webCrawlingFilters, (draft) => {
+          draft.excludePatterns[idx] = pattern;
+        })
+      );
+    },
+    [webCrawlingFilters]
+  );
+
+  const onClickAddExcludePattern = useCallback(() => {
+    setWebCrawlingFilters(
+      produce(webCrawlingFilters, (draft) => {
+        draft.excludePatterns.push('');
+      })
+    );
+  }, [webCrawlingFilters]);
+
+  const onClickRemoveExcludePattern = useCallback(
+    (idx: number) => {
+      setWebCrawlingFilters(
+        produce(webCrawlingFilters, (draft) => {
+          draft.excludePatterns.splice(idx, 1);
+          if (draft.excludePatterns.length === 0) {
+            draft.excludePatterns.push('');
+          }
+        })
+      );
+    },
+    [webCrawlingFilters]
+  );
+
   useEffect(() => {
     if (!isNewBot) {
       setIsLoading(true);
@@ -391,6 +488,11 @@ const BotKbEditPage: React.FC = () => {
               : 0
           );
           setParsingModel(bot.bedrockKnowledgeBase.parsingModel);
+          setWebCrawlingScope(bot.bedrockKnowledgeBase.webCrawlingScope ?? 'DEFAULT');
+          setWebCrawlingFilters({
+            includePatterns: bot.bedrockKnowledgeBase.webCrawlingFilters?.includePatterns || [''],
+            excludePatterns: bot.bedrockKnowledgeBase.webCrawlingFilters?.excludePatterns || [''],
+          });
         })
         .finally(() => {
           setIsLoading(false);
@@ -433,6 +535,36 @@ const BotKbEditPage: React.FC = () => {
       );
     },
     [s3Urls]
+  );
+
+  const onChangeUrls = useCallback(
+    (url: string, idx: number) => {
+      setUrls(
+        produce(urls, (draft) => {
+          draft[idx] = url;
+        })
+      );
+    },
+    [urls]
+  );
+
+  const onClickAddUrls = useCallback(() => {
+    setUrls([...urls, '']);
+  }, [urls]);
+
+  const onClickRemoveUrls = useCallback(
+    (idx: number) => {
+      setUrls(
+        produce(urls, (draft) => {
+          draft.splice(idx, 1);
+          if (draft.length === 0) {
+            draft.push('');
+          }
+          return;
+        })
+      );
+    },
+    [urls]
   );
 
   const removeUnchangedFilenames = useCallback(
@@ -907,6 +1039,8 @@ const BotKbEditPage: React.FC = () => {
         openSearch: openSearchParams,
         searchParams: searchParams,
         parsingModel,
+        webCrawlingScope,
+        webCrawlingFilters,
       },
       bedrockGuardrails: {
         isGuardrailEnabled:
@@ -969,6 +1103,8 @@ const BotKbEditPage: React.FC = () => {
     groundingThreshold,
     relevanceThreshold,
     parsingModel,
+    webCrawlingScope,
+    webCrawlingFilters,
   ]);
 
   const onClickEdit = useCallback(() => {
@@ -1024,6 +1160,8 @@ const BotKbEditPage: React.FC = () => {
           openSearch: openSearchParams,
           searchParams: searchParams,
           parsingModel,
+          webCrawlingScope,
+          webCrawlingFilters,
         },
         bedrockGuardrails: {
           isGuardrailEnabled:
@@ -1092,6 +1230,8 @@ const BotKbEditPage: React.FC = () => {
     guardrailArn,
     guardrailVersion,
     parsingModel,
+    webCrawlingScope,
+    webCrawlingFilters,
   ]);
 
   const [isOpenSamples, setIsOpenSamples] = useState(false);
@@ -1241,6 +1381,148 @@ const BotKbEditPage: React.FC = () => {
                       {t('button.add')}
                     </Button>
                   </div>
+                </div>
+
+                <div className="mt-4">
+                  <div className="font-semibold">{t('bot.label.url')}</div>
+                  <div className="text-sm text-aws-font-color/50">
+                    {t('bot.help.knowledge.url')}
+                  </div>
+                  <div className="mt-2 flex w-full flex-col gap-1">
+                    {urls.map((url, idx) => (
+                      <div className="flex w-full gap-2" key={idx}>
+                        <InputText
+                          className="w-full"
+                          type="text"
+                          disabled={isLoading}
+                          value={url}
+                          placeholder="https://example.com"
+                          onChange={(s) => {
+                            onChangeUrls(s, idx);
+                          }}
+                          errorMessage={errorMessages[`urls-${idx}`]}
+                        />
+                        <ButtonIcon
+                          className="text-red"
+                          disabled={
+                            (urls.length === 1 && !url[0]) || isLoading
+                          }
+                          onClick={() => {
+                            onClickRemoveUrls(idx);
+                          }}>
+                          <PiTrash />
+                        </ButtonIcon>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-2">
+                    <Button
+                      outlined
+                      icon={<PiPlus />}
+                      disabled={urls.length >= 10}
+                      onClick={onClickAddUrls}>
+                      {t('button.add')}
+                    </Button>
+                  </div>
+
+                  <ExpandableDrawerGroup
+                    isDefaultShow={false}
+                    label={t('knowledgeBaseSettings.webCrawlerConfig.title')}
+                    className="py-2">
+
+                    <div className="mt-3">
+                      <Select
+                        label={t('knowledgeBaseSettings.webCrawlerConfig.crawlingScope.label')}
+                        value={webCrawlingScope}
+                        options={webCrawlingScopeOptions}
+                        onChange={(val) => {
+                          setWebCrawlingScope(val as WebCrawlingScope);
+                        }}
+                      />
+                    </div>
+
+                    <div className="mt-4">
+                      <div className="font-semibold">{t('knowledgeBaseSettings.webCrawlerConfig.includePatterns.label')}</div>
+                      <div className="text-sm text-aws-font-color/50">
+                        {t('knowledgeBaseSettings.webCrawlerConfig.includePatterns.hint')}
+                      </div>
+                      <div className="mt-2 flex w-full flex-col gap-1">
+                        {webCrawlingFilters.includePatterns.map((pattern, idx) => (
+                          <div className="flex w-full gap-2" key={idx}>
+                            <InputText
+                              className="w-full"
+                              type="text"
+                              disabled={isLoading}
+                              value={pattern}
+                              placeholder=".*\.html$"
+                              onChange={(s) => {
+                                onChangeIncludePattern(s, idx);
+                              }}
+                            />
+                            <ButtonIcon
+                              className="text-red"
+                              disabled={
+                                (webCrawlingFilters.includePatterns.length === 1 && !pattern) || isLoading
+                              }
+                              onClick={() => {
+                                onClickRemoveIncludePattern(idx);
+                              }}>
+                              <PiTrash />
+                            </ButtonIcon>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="mt-2">
+                        <Button
+                          outlined
+                          icon={<PiPlus />}
+                          onClick={onClickAddIncludePattern}>
+                          {t('button.add')}
+                        </Button>
+                      </div>
+                    </div>
+                  
+                    <div className="mt-4">
+                      <div className="font-semibold">{t('knowledgeBaseSettings.webCrawlerConfig.excludePatterns.label')}</div>
+                      <div className="text-sm text-aws-font-color/50">
+                        {t('knowledgeBaseSettings.webCrawlerConfig.excludePatterns.hint')}
+                      </div>
+                      <div className="mt-2 flex w-full flex-col gap-1">
+                        {webCrawlingFilters.excludePatterns.map((pattern, idx) => (
+                          <div className="flex w-full gap-2" key={idx}>
+                            <InputText
+                              className="w-full"
+                              type="text"
+                              disabled={isLoading}
+                              value={pattern}
+                              placeholder=".*\.pdf$"
+                              onChange={(s) => {
+                                onChangeExcludePattern(s, idx);
+                              }}
+                            />
+                            <ButtonIcon
+                              className="text-red"
+                              disabled={
+                                (webCrawlingFilters.excludePatterns.length === 1 && !pattern) || isLoading
+                              }
+                              onClick={() => {
+                                onClickRemoveExcludePattern(idx);
+                              }}>
+                              <PiTrash />
+                            </ButtonIcon>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="mt-2">
+                        <Button
+                          outlined
+                          icon={<PiPlus />}
+                          onClick={onClickAddExcludePattern}>
+                          {t('button.add')}
+                        </Button>
+                      </div>
+                    </div>
+                  </ExpandableDrawerGroup>
                 </div>
 
                 <div className="mt-4">

--- a/frontend/src/features/knowledgeBase/types/index.d.ts
+++ b/frontend/src/features/knowledgeBase/types/index.d.ts
@@ -5,9 +5,12 @@ export type BedrockKnowledgeBase = {
   chunkingConfiguration: ChunkingConfiguration;
   openSearch: OpenSearchParams;
   searchParams: SearchParams;
+  parsingModel?: ParsingModel;
 };
 
 export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
+
+export type ParsingModel = 'anthropic.claude-3-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
 
 export type ChunkingStrategy = 'default' | 'fixed_size' | 'hierarchical' | 'semantic' | 'none';
 

--- a/frontend/src/features/knowledgeBase/types/index.d.ts
+++ b/frontend/src/features/knowledgeBase/types/index.d.ts
@@ -6,6 +6,8 @@ export type BedrockKnowledgeBase = {
   openSearch: OpenSearchParams;
   searchParams: SearchParams;
   parsingModel?: ParsingModel;
+  webCrawlingScope?: WebCrawlingScope;
+  webCrawlingFilters?: WebCrawlingFilters;
 };
 
 export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
@@ -13,6 +15,13 @@ export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
 export type ParsingModel = 'anthropic.claude-3-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
 
 export type ChunkingStrategy = 'default' | 'fixed_size' | 'hierarchical' | 'semantic' | 'none';
+
+export type WebCrawlingScope = 'DEFAULT' | 'SUBDOMAINS' | 'HOST_ONLY';
+
+export type WebCrawlingFilters = {
+  excludePatterns: string[];
+  includePatterns: string[];
+};
 
 export type ChunkingConfiguration = DefaultParams | FixedSizeParams | HierarchicalParams | SemanticParams | NoneParams;
 

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -54,7 +54,7 @@ const translation = {
         knowledge: {
           overview:
             'Indem man dem Bot eine externe Wissensbasis zur Verfügung stellt, wird er in die Lage versetzt, mit Daten umzugehen, für die er nicht vorher trainiert wurde.',
-          url: 'Die Informationen aus der angegebenen URL werden als Wissensbasis verwendet. Wenn Sie die URL eines YouTube-Videos angeben, wird das Transkript dieses Videos als Wissensbasis verwendet.',
+          url: 'Die Informationen aus der angegebenen URL werden als Wissensbasis verwendet.',
           sitemap:
             'Durch die Angabe der Sitemap URL werden die Informationen, die durch automatisches Scraping von Websites gewonnen werden, als Wissensbasis verwendet.',
           file: 'Die hochgeladenen Dateien werden als Wissensbasis verwendet.',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -157,7 +157,7 @@ const translation = {
         knowledge: {
           overview:
             'By providing external knowledge to the bot, it becomes able to handle data that it has not been pre-trained on.',
-          url: 'The information from the specified URL will be used as Knowledge. If you set the URL of a YouTube video, the transcript of that video will be used as Knowledge.',
+          url: 'The information from the specified URL will be used as Knowledge.',
           s3url:
             'By entering the S3 URI, you can add S3 as a data source. You can add up to 4 sources. It only supports buckets that exist in the same account and the same region as bedrock region.',
           sitemap:
@@ -655,7 +655,7 @@ How would you categorize this email?`,
       parsingModel: {
         label: 'Advanced Parsing Model',
         none: {
-          label: 'Disabled',
+          label: 'None',
           hint: 'No advanced parsing will be applied.',
         },
         claude_3_sonnet: {
@@ -666,7 +666,34 @@ How would you categorize this email?`,
           label: 'Claude 3 Haiku',
           hint: 'Use Claude 3 Haiku for advanced document parsing.',
         }
+      },
+      webCrawlerConfig: {
+        title: 'Web Crawler Config',
+        crawlingScope: {
+          label: 'Crawling Scope',
+          default: {
+            label: 'Default',
+            hint: 'Limit crawling to web pages that belong to the same host and with the same initial URL path. For example, with a seed URL of "https://aws.amazon.com/bedrock/" then only this path and web pages that extend from this path will be crawled, like "https://aws.amazon.com/bedrock/agents/". Sibling URLs like "https://aws.amazon.com/ec2/" are not crawled, for example.',
+          },
+          subdomains: {
+            label: 'Subdomains',
+            hint: 'Include crawling of any web page that has the same primary domain as the seed URL. For example, with a seed URL of "https://aws.amazon.com/bedrock/" then any web page that contains "amazon.com" will be crawled, like "https://www.amazon.com".',
+          },
+          hostOnly: {
+            label: 'Host Only',
+            hint: 'Limit crawling to web pages that belong to the same host. For example, with a seed URL of "https://aws.amazon.com/bedrock/", then web pages with "https://docs.aws.amazon.com" will also be crawled, like "https://aws.amazon.com/ec2".',
+          },
+        },
+        includePatterns: {
+          label: 'Include Patterns',
+          hint: 'Specify patterns to include in web crawling. Only URLs matching these patterns will be crawled.',
+        },
+        excludePatterns: {
+          label: 'Exclude Patterns',
+          hint: 'Specify patterns to exclude from web crawling. URLs matching these patterns will not be crawled.',
+        },
       }
+      
     },
     error: {
       answerResponse: 'An error occurred while responding.',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -120,6 +120,7 @@ const translation = {
         noBots: 'No Bots.',
         noBotsRecentlyUsed: 'No Recently Used Shared Bots.',
         retrievingKnowledge: '[Retrieving Knowledge...]',
+        selectParsingModel: 'Select Parsing Model',
         dndFileUpload:
           'You can upload files by drag and drop.\nSupported files: {{fileExtensions}}',
         uploadError: 'Error Message',
@@ -647,6 +648,25 @@ How would you categorize this email?`,
         token_filter: 'Token Filter:',
         not_specified: 'Not specified',
       },
+      advancedParsing: {
+        label: 'Advanced Parsing',
+        description: 'Select a model to use for advanced document parsing capabilities.'
+      },
+      parsingModel: {
+        label: 'Advanced Parsing Model',
+        none: {
+          label: 'Disabled',
+          hint: 'No advanced parsing will be applied.',
+        },
+        claude_3_sonnet: {
+          label: 'Claude 3 Sonnet',
+          hint: 'Use Claude 3 Sonnet for advanced document parsing.',
+        },
+        claude_3_haiku: {
+          label: 'Claude 3 Haiku',
+          hint: 'Use Claude 3 Haiku for advanced document parsing.',
+        }
+      }
     },
     error: {
       answerResponse: 'An error occurred while responding.',

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -117,7 +117,7 @@ const translation = {
         knowledge: {
           overview:
             'Al proporcionar conocimiento externo al bot, se vuelve capaz de manejar datos con los que no ha sido preentrenado.',
-          url: 'La información de la URL especificada será utilizada como Conocimiento. Si configuras la URL de un video de YouTube, la transcripción de ese video será utilizada como Conocimiento.',
+          url: 'La información de la URL especificada será utilizada como Conocimiento.',
           s3url:
             'Al ingresar la URI de S3, puedes agregar S3 como una fuente de datos. Puedes agregar hasta 4 fuentes. Solo soporta buckets que existan en la misma cuenta y región que Bedrock.',
           sitemap:

--- a/frontend/src/i18n/fr/index.ts
+++ b/frontend/src/i18n/fr/index.ts
@@ -54,7 +54,7 @@ const translation = {
         knowledge: {
           overview:
             "En fournissant des connaissances externes au bot, celui-ci devient capable de gérer des données sur lesquelles il n'a pas été pré-entraîné.",
-          url: "Les informations de l'URL spécifiée seront utilisées comme connaissances. Si vous définissez l'URL d'une vidéo YouTube, la transcription de cette vidéo sera utilisée comme connaissance.",
+          url: "Les informations de l'URL spécifiée seront utilisées comme connaissances.",
           sitemap:
             "En spécifiant l'URL du plan du site, les informations obtenues en grattant automatiquement les sites Web qu'il contient seront utilisées comme connaissances.",
           file: 'Les fichiers téléchargés seront utilisés comme connaissances.',

--- a/frontend/src/i18n/it/index.ts
+++ b/frontend/src/i18n/it/index.ts
@@ -60,7 +60,7 @@ const translation = {
         knowledge: {
           overview:
             'Fornendo conoscenza esterna al Bot, il Bot diventa in grado di gestire dati su cui non è stato pre-addestrato.',
-          url: "Le informazioni dall'URL specificato verranno utilizzate come Apprendimento. Se imposti l'URL di un video di YouTube, la trascrizione di quel video verrà utilizzata come Apprendimento.",
+          url: "Le informazioni dall'URL specificato verranno utilizzate come Apprendimento.",
           sitemap:
             "Specificando l'URL della mappa del sito, le informazioni ottenute attraverso lo scraping automatico dei siti Web al suo interno verranno utilizzate come Apprendimento.",
           file: 'I file caricati verranno utilizzati come Apprendimento.',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -158,7 +158,7 @@ const translation = {
         knowledge: {
           overview:
             '外部の情報をボットに提供することで、事前学習していないデータを扱えるようになります。',
-          url: 'URLを指定すると、そのURLの情報がナレッジとして利用されます。YouTube の動画の URL を設定すると、その動画の字幕がナレッジとして利用されます。',
+          url: 'URLを指定すると、そのURLの情報がナレッジとして利用されます。',
           s3url:
             'S3 の URI を入力し、S3 をデータソースとして追加します。最大 4 件追加できます。Bedrock利用リージョンと同じアカウント・同じリージョンに存在するバケットのみ対応しています。',
           sitemap:
@@ -662,6 +662,32 @@ const translation = {
           label: 'Claude 3 Haiku',
           hint: 'Claude 3 Haikuを使用してドキュメントの高度な解析を行います。',
         }
+      },
+      webCrawlerConfig: {
+        title: 'Webクローラーの設定',
+        crawlingScope: {
+          label: 'スコープ',
+          default:{
+            label: 'デフォルト',
+            hint: 'クロールを、同じホストに属し、同じ初期URLパスを持つウェブページに制限します。例えば、シードURLが "https://aws.amazon.com/bedrock/" の場合、このパスとこのパスから派生するウェブページのみがクロールされます。例えば "https://aws.amazon.com/bedrock/agents/" などです。"https://aws.amazon.com/ec2/" のような兄弟URLはクロールされません。'
+          },
+          subdomains: {
+            label: 'サブドメイン',
+            hint: 'シードURLと同じプライマリドメインを持つすべてのウェブページのクロールを含めます。例えば、シードURLが "https://aws.amazon.com/bedrock/" の場合、"amazon.com" を含むすべてのウェブページがクロールされます。"https://www.amazon.com" のようなページも含まれます。'
+          },
+          hostOnly: {
+            label: 'ホストオンリー',
+            hint: 'クロールを同じホストに属するウェブページに制限します。例えば、シードURLが "https://aws.amazon.com/bedrock/" の場合、"https://docs.aws.amazon.com" のようなウェブページもクロールされます。"https://aws.amazon.com/ec2" のようなページも含まれます。'
+          }
+        },
+        includePatterns: {
+          label: 'Include Patterns',
+          hint: 'ウェブクロールに含めるパターンを指定します。これらのパターンに一致するURLのみがクロールされます。',
+        },
+        excludePatterns: {
+          label: 'Exclude Patterns',
+          hint: 'ウェブクロールから除外するパターンを指定します。これらのパターンに一致するURLはクロールされません。',
+        },
       }
     },
     error: {

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -644,6 +644,25 @@ const translation = {
         token_filter: 'トークンフィルター:',
         not_specified: '指定なし',
       },
+      advancedParsing: {
+        label: '高度なドキュメント解析機能',
+        description: 'ドキュメントの高度なドキュメント解析機能に使用するモデルを選択してください。'
+      },
+      parsingModel: {
+        label: '高度なパースモデル',
+        none: {
+          label: 'なし',
+          hint: 'ドキュメントの高度な解析機能は適用されません。',
+        },
+        claude_3_sonnet: {
+          label: 'Claude 3 Sonnet',
+          hint: 'Claude 3 Sonnetを使用してドキュメントの高度な解析を行います。',
+        },
+        claude_3_haiku: {
+          label: 'Claude 3 Haiku',
+          hint: 'Claude 3 Haikuを使用してドキュメントの高度な解析を行います。',
+        }
+      }
     },
     error: {
       answerResponse: '回答中にエラーが発生しました。',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -682,11 +682,11 @@ const translation = {
           }
         },
         includePatterns: {
-          label: 'Include Patterns',
+          label: 'ウェブクロールに含めるパターン',
           hint: 'ウェブクロールに含めるパターンを指定します。これらのパターンに一致するURLのみがクロールされます。',
         },
         excludePatterns: {
-          label: 'Exclude Patterns',
+          label: 'ウェブクロールに含めないパターン',
           hint: 'ウェブクロールから除外するパターンを指定します。これらのパターンに一致するURLはクロールされません。',
         },
       }

--- a/frontend/src/i18n/nb/index.ts
+++ b/frontend/src/i18n/nb/index.ts
@@ -117,7 +117,7 @@ const translation = {
                 knowledge: {
                     overview:
                         'Ved å gi ekstern kunnskap til boten, blir den i stand til å håndtere data den ikke er forhåndstrent på.',
-                    url: 'Informasjonen fra den spesifiserte URL-en vil bli brukt som kunnskap. Hvis du angir URL-en til en YouTube-video, vil transkripsjonen av den videoen bli brukt som kunnskap.',
+                    url: 'Informasjonen fra den spesifiserte URL-en vil bli brukt som kunnskap.',
                     s3url:
                         'Ved å angi S3 URI kan du legge til S3 som en datakilde. Du kan legge til opptil 4 kilder. Det støtter kun bøtter som eksisterer i samme konto og samme region som distribusjonsdestinasjonen.',
                     sitemap:

--- a/frontend/src/i18n/zh-hans/index.ts
+++ b/frontend/src/i18n/zh-hans/index.ts
@@ -58,7 +58,7 @@ const translation = {
         knowledge: {
           overview:
             '透过向 Bot 提供外部知识，它就能够回答那些不包括在预训练资料的问题。',
-          url: '透过 URL 指定网页内容作为知识。 如果您设定 YouTube 影片的 URL，该影片的文字记录将作为知识。',
+          url: '透过 URL 指定网页内容作为知识。',
           sitemap:
             '透过指定网站的 sitemap URL，Bot 将自动抓取 sitemap 中的网页资讯作为知识。',
           file: '上传的档案将作为知识。 ',

--- a/frontend/src/i18n/zh-hant/index.ts
+++ b/frontend/src/i18n/zh-hant/index.ts
@@ -58,7 +58,7 @@ const translation = {
         knowledge: {
           overview:
             '透過向 Bot 提供外部知識，它就能夠回答那些不包括在預訓練資料的問題。',
-          url: '透過 URL 指定網頁內容作為知識。如果您設定 YouTube 影片的 URL，該影片的文字記錄將作為知識。',
+          url: '透過 URL 指定網頁內容作為知識。',
           sitemap:
             '透過指定網站的 sitemap URL，Bot 將自動抓取 sitemap 中的網頁資訊作為知識。',
           file: '上傳的檔案將作為知識。',


### PR DESCRIPTION
*Issue #, if available:*]
#557 

*Description of changes:*
Add Web Crawler for Knowledge Bases.
We can set 10 URLs for websites to be crawled.
You can also set URL inclusion/exclusion patterns.

I'm reusing v1 sourceUrls that aren't used in v2. Since Youtube is not supported, the description about Youtube has been removed. 

![Screenshot 2024-11-19 at 10 41 55](https://github.com/user-attachments/assets/57395f05-4553-41e3-bbe2-cb2dab47c78c)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
