### PR TITLE
fix: enable public API access without knowledge

### DIFF
--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -288,7 +288,7 @@ def chat(user_id: str, chat_input: ChatInput) -> ChatOutput:
     else:
         message_map = conversation.message_map
         search_results = []
-        if bot and is_running_on_lambda():
+        if bot and bot.has_knowledge() and is_running_on_lambda():
             # NOTE: `is_running_on_lambda`is a workaround for local testing due to no postgres mock.
             # Fetch most related documents from vector store
             # NOTE: Currently embedding not support multi-modal. For now, use the last content.


### PR DESCRIPTION
*Issue #, if available:*
#598 

*Description of changes:*
In `/backend/app/usecases/chat.py`, I modified it to search the docs only when the bot has knowledge registered.
(This ensures that the public API without knowledge works correctly.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
