### PR TITLE
fix: Bot creation with web crawling fails when specify sites with deep nest

### DIFF
--- a/backend/embedding_statemachine/bedrock_knowledge_base/update_bot_status.py
+++ b/backend/embedding_statemachine/bedrock_knowledge_base/update_bot_status.py
@@ -81,8 +81,8 @@ def handler(event, context):
             pk = event["pk"]
             sk = event["sk"]
             sync_status = "FAILED"
-            sync_status_reason = str(ingestion_job["IngestionJob"]["FailureReasons"])
-            last_exec_id = ingestion_job["IngestionJob"]["IngestionJobId"]
+            sync_status_reason = str(ingestion_job["ingestionJob"]["failureReasons"])
+            last_exec_id = ingestion_job["ingestionJob"]["ingestionJobId"]
         else:
             pk = event["pk"]
             sk = event["sk"]


### PR DESCRIPTION
*Issue #, if available:*
#605 

*Description of changes:*
In the case of knowledge base synchronization failure, dynamodb was not updated, and the status of a sync error did not occur. The cause was typo, so I fixed it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
