### PR TITLE
Fix: Error when clicking on reference links.

### DIFF
--- a/backend/app/repositories/models/conversation.py
+++ b/backend/app/repositories/models/conversation.py
@@ -648,7 +648,7 @@ class RelatedDocumentModel(BaseModel):
         if url.scheme == "s3":
             source_link = generate_presigned_url(
                 bucket=url.netloc,
-                key=url.path,
+                key=url.path.removeprefix("/"),
                 client_method="get_object",
             )
             return source_link


### PR DESCRIPTION
- Remove leading slash from S3 object key when generating pre-signed URLs.

*Issue #, if available:*
Closes #646 

*Description of changes:*
Remove leading slash from S3 object key when generating pre-signed URLs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
