### PR TITLE
fix: fixes 422 errors in fetch_bot_summary for bots with no existing alias

### DIFF
--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -633,8 +633,10 @@ def fetch_all_bots(
 
 
 def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
+    logger.info(f"Fetching bot summary - userId:{user_id}, botId:{bot_id}")
     try:
         bot = find_private_bot_by_id(user_id, bot_id)
+        logger.info(f"Found private bot by id: {bot.id}")
         return BotSummaryOutput(
             id=bot_id,
             title=bot.title,
@@ -662,9 +664,11 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
 
     try:
         alias = find_alias_by_id(user_id, bot_id)
+        logger.info(f"Found alias by id: {alias}")
 
         # update bot model activate if alias is found.
         bot = find_public_bot_by_id(bot_id)
+        logger.info(f"Found bot by bot_id: {bot}")
 
         return BotSummaryOutput(
             id=alias.id,
@@ -697,6 +701,8 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
     try:
         # NOTE: At the first time using shared bot, alias is not created yet.
         bot = find_public_bot_by_id(bot_id)
+        logger.info(f"Found bot by bot_id: {bot}")
+        logger.info("This is first time being accessed, so creating alias")
         current_time = get_current_time()
         # Store alias when opened shared bot page
         store_alias(
@@ -719,9 +725,7 @@ def fetch_bot_summary(user_id: str, bot_id: str) -> BotSummaryOutput:
                     )
                     for starter in bot.conversation_quick_starters
                 ],
-                active_models=ActiveModelsOutput.model_validate(
-                    dict(bot.active_models)
-                ),
+                active_models=bot.active_models,
             ),
         )
         return BotSummaryOutput(

--- a/backend/tests/test_usecases/test_bot.py
+++ b/backend/tests/test_usecases/test_bot.py
@@ -1,7 +1,12 @@
+import datetime
+import logging
 import sys
 
 sys.path.insert(0, ".")
 import unittest
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
 
 from pydantic import BaseModel
 
@@ -23,6 +28,12 @@ from app.repositories.custom_bot import (
 )
 
 from app.usecases.bot import fetch_all_bots_by_user_id, issue_presigned_url
+
+from app.repositories.common import RecordNotFoundError
+from app.repositories.models.custom_bot import BotAliasModel, BotModel, AgentModel, GenerationParamsModel, KnowledgeModel, ActiveModelsModel
+from app.routes.schemas.bot import BotSummaryOutput, ConversationQuickStarter, ActiveModelsOutput
+from app.usecases.bot import fetch_bot_summary
+from unittest.mock import patch, MagicMock
 
 
 class TestIssuePresignedUrl(unittest.TestCase):
@@ -141,6 +152,201 @@ class TestFindAllBots(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(bots[4].id, self.third_bot_id)
         self.assertEqual(bots[5].id, self.first_bot_id)
 
+
+class TestFetchBotSummary(unittest.TestCase):
+
+    def setUp(self):
+        self._logging_stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(self._logging_stream_handler)
+    
+    def tearDown(self):
+        logger.removeHandler(self._logging_stream_handler)
+
+    @patch('app.usecases.bot.find_private_bot_by_id')
+    @patch('app.usecases.bot.find_alias_by_id')  
+    @patch('app.usecases.bot.find_public_bot_by_id')
+    def test_fetch_bot_summary_alias_bot(self, mock_find_public, mock_find_alias, mock_find_private):
+        """Test fetch_bot_summary for an alias bot - where an alias already exists"""
+
+        mock_public_bot = BotModel(
+            id="public_bot_id",
+            title="Test Public Bot", 
+            description="A test public bot",
+            instruction="Test instruction",
+            create_time=1234567890,
+            last_used_time=1234567891,
+            is_pinned=True,
+            public_bot_id=None,
+            owner_user_id="test_owner",
+            generation_params=GenerationParamsModel(max_tokens=1,temperature=1,top_k=1,top_p=1,stop_sequences=["Test"]),
+            agent=AgentModel(tools=[]),
+            knowledge=KnowledgeModel(source_urls=[], sitemap_urls=[], filenames=[], s3_urls=[]),
+            sync_status="SUCCEEDED",
+            sync_status_reason="",
+            sync_last_exec_id="",
+            display_retrieved_chunks=True,
+            conversation_quick_starters=[],
+            bedrock_knowledge_base=None,
+            bedrock_guardrails=None,
+            active_models=ActiveModelsModel(chat="claude-v1", embedding="amazon.titan-embed-text-v1"),
+            published_api_codebuild_id='test',
+            published_api_datetime=1704067200,  # 2024-01-01 00:00:00 UTC
+            published_api_stack_name='test'
+        )
+        mock_find_public.return_value = mock_public_bot
+
+        mock_find_private.side_effect = RecordNotFoundError()
+        mock_alias = BotAliasModel(
+            id="alias_bot_id",
+            title=mock_public_bot.title,
+            description=mock_public_bot.description,
+            original_bot_id=mock_public_bot.id,
+            create_time=1234567890,
+            last_used_time=1234567891,
+            is_pinned=mock_public_bot.is_pinned,
+            sync_status=mock_public_bot.sync_status,
+            has_knowledge=mock_public_bot.has_knowledge(),
+            has_agent=True,
+            conversation_quick_starters=mock_public_bot.conversation_quick_starters,
+            active_models=mock_public_bot.active_models
+        )
+        mock_find_alias.return_value = mock_alias
+
+        result = fetch_bot_summary("valid_user_id", "public_bot_id")
+        
+        self.assertEqual(result.id, "alias_bot_id") 
+        self.assertFalse(result.owned)
+        self.assertTrue(result.is_public)
+        
+    @patch('app.usecases.bot.find_private_bot_by_id')
+    @patch('app.usecases.bot.find_alias_by_id')
+    @patch('app.usecases.bot.find_public_bot_by_id')
+    def test_fetch_bot_summary_incorrect_type(self, mock_find_public, mock_find_alias, mock_find_private):
+        """Test fetch_bot_summary with incorrect input types"""
+        with self.assertRaises(TypeError):
+            fetch_bot_summary(123, "valid_bot_id")
+        
+        with self.assertRaises(TypeError):
+            fetch_bot_summary("valid_user_id", 456)
+
+    @patch('app.usecases.bot.find_private_bot_by_id')
+    @patch('app.usecases.bot.find_alias_by_id')
+    @patch('app.usecases.bot.find_public_bot_by_id')
+    def test_fetch_bot_summary_invalid_input(self, mock_find_public, mock_find_alias, mock_find_private):
+        """Test fetch_bot_summary with invalid input"""
+        with self.assertRaises(ValueError):
+            fetch_bot_summary("", "valid_bot_id")
+        
+        with self.assertRaises(ValueError):
+            fetch_bot_summary("valid_user_id", "")
+
+    @patch('app.usecases.bot.find_private_bot_by_id')
+    @patch('app.usecases.bot.find_alias_by_id')
+    @patch('app.usecases.bot.find_public_bot_by_id')
+    def test_fetch_bot_summary_not_found(self, mock_find_public, mock_find_alias, mock_find_private):
+        """Test fetch_bot_summary when bot is not found"""
+        mock_find_private.side_effect = RecordNotFoundError()
+        mock_find_alias.side_effect = RecordNotFoundError()
+        mock_find_public.side_effect = RecordNotFoundError()
+
+        with self.assertRaises(RecordNotFoundError):
+            fetch_bot_summary("valid_user_id", "non_existent_bot_id")
+
+    def test_fetch_bot_summary_private_bot(self):
+        """Test fetch_bot_summary for a private bot"""
+        user_id = "test_user"
+        bot_id = "test_bot"
+        
+        mock_bot = BotModel(
+            id=bot_id,
+            title="Test Bot",
+            description="A test bot",
+            instruction="Test instruction",
+            create_time=1234567890,
+            last_used_time=1234567891,
+            is_pinned=True,
+            public_bot_id=None,
+            owner_user_id=user_id,
+            generation_params=None,
+            agent=AgentModel(tools=[]),
+            knowledge=KnowledgeModel(source_urls=["https://example.com"], sitemap_urls=[], filenames=[], s3_urls=[]),
+            sync_status="SUCCEEDED",
+            sync_status_reason="",
+            sync_last_exec_id="",
+            display_retrieved_chunks=True,
+            conversation_quick_starters=[
+                ConversationQuickStarter(title="Quick Start 1", example="Example 1")
+            ],
+            bedrock_knowledge_base=None,
+            bedrock_guardrails=None,
+            active_models=ActiveModelsModel(chat="claude-v1", embedding="amazon.titan-embed-text-v1")
+        )
+
+        with patch('app.usecases.bot.find_private_bot_by_id', return_value=mock_bot):
+            result = fetch_bot_summary(user_id, bot_id)
+
+        expected_output = BotSummaryOutput(
+            id=bot_id,
+            title="Test Bot",
+            description="A test bot",
+            create_time=1234567890,
+            last_used_time=1234567891,
+            is_pinned=True,
+            is_public=False,
+            has_agent=False,
+            owned=True,
+            sync_status="SUCCEEDED",
+            has_knowledge=True,
+            conversation_quick_starters=[
+                ConversationQuickStarter(title="Quick Start 1", example="Example 1")
+            ],
+            active_models=ActiveModelsOutput(chat="claude-v1", embedding="amazon.titan-embed-text-v1")
+        )
+
+        self.assertEqual(result, expected_output)
+
+    @patch('app.usecases.bot.find_private_bot_by_id')
+    @patch('app.usecases.bot.find_alias_by_id')
+    @patch('app.usecases.bot.find_public_bot_by_id')
+    @patch('app.usecases.bot.store_alias')
+    def test_fetch_bot_summary_public_bot_no_alias(self, mock_store_alias, mock_find_public, mock_find_alias, mock_find_private):
+        """Test fetch_bot_summary for a public bot without an existing alias"""
+        mock_find_private.side_effect = RecordNotFoundError()
+        mock_find_alias.side_effect = RecordNotFoundError()
+        mock_public_bot = BotModel(
+            id="public_bot_id",
+            title="Test Public Bot", 
+            description="A test public bot",
+            instruction="Test instruction",
+            create_time=1234567890,
+            last_used_time=1234567891,
+            is_pinned=True,
+            public_bot_id=None,
+            owner_user_id="test_owner",
+            generation_params=GenerationParamsModel(max_tokens=1,temperature=1,top_k=1,top_p=1,stop_sequences=["Test"]),
+            agent=AgentModel(tools=[]),
+            knowledge=KnowledgeModel(source_urls=[], sitemap_urls=[], filenames=[], s3_urls=[]),
+            sync_status="SUCCEEDED",
+            sync_status_reason="",
+            sync_last_exec_id="",
+            display_retrieved_chunks=True,
+            conversation_quick_starters=[],
+            bedrock_knowledge_base=None,
+            bedrock_guardrails=None,
+            active_models=ActiveModelsModel(chat="claude-v1", embedding="amazon.titan-embed-text-v1"),
+            published_api_codebuild_id='test',
+            published_api_datetime=1704067200,  # 2024-01-01 00:00:00 UTC
+            published_api_stack_name='test'
+        )
+        mock_public_bot.id = "public_bot_id"
+        mock_find_public.return_value = mock_public_bot
+
+        result = fetch_bot_summary("valid_user_id", "public_bot_id")
+        
+        self.assertEqual(result.id, "public_bot_id")
+        self.assertFalse(result.owned)
+        self.assertTrue(result.is_public)
+        mock_store_alias.assert_called_once()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
*Issue #, if available:* #651

*Description of changes:*
This change alters active_models to use the existing (valid) bot definition for the use case where a bot is public but doesn't have an alias. Previously this used the ActiveModelsOutput but that's the wrong type for a BotAlias signature.

I've also added some logging.

I've also covered fetch_bot_summary in unit tests - note: unlike the other tests, these are mocked and don't actually require AWS infrastructure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
