### PR TITLE
Add dead letter queue to API stack, to limit retries

### DIFF
--- a/cdk/lib/api-publishment-stack.ts
+++ b/cdk/lib/api-publishment-stack.ts
@@ -33,8 +33,15 @@ export class ApiPublishmentStack extends Stack {
 
     const deploymentStage = props.deploymentStage ?? "dev";
 
+    const chatQueueDLQ = new sqs.Queue(this, "ChatQueue-DLQ", {
+      retentionPeriod: cdk.Duration.days(14),
+    });
     const chatQueue = new sqs.Queue(this, "ChatQueue", {
       visibilityTimeout: cdk.Duration.minutes(30),
+      deadLetterQueue: {
+        maxReceiveCount: 2, // one retry
+        queue: chatQueueDLQ,
+      },
     });
 
     const handlerRole = new iam.Role(this, "HandlerRole", {

--- a/cdk/lib/api-publishment-stack.ts
+++ b/cdk/lib/api-publishment-stack.ts
@@ -33,7 +33,7 @@ export class ApiPublishmentStack extends Stack {
 
     const deploymentStage = props.deploymentStage ?? "dev";
 
-    const chatQueueDLQ = new sqs.Queue(this, "ChatQueue-DLQ", {
+    const chatQueueDLQ = new sqs.Queue(this, "ChatQueueDlq", {
       retentionPeriod: cdk.Duration.days(14),
     });
     const chatQueue = new sqs.Queue(this, "ChatQueue", {


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

When published API handler failed, message in SQS queue will remain in the queue and retry occurs every 30 minutes for 4 days (192 times). This can cause unwanted mass usage of foundation model.

This PR adds dead-letter-queue to the queue and limit max retry count to 1.

* [`cdk/lib/api-publishment-stack.ts`](diffhunk://#diff-f8b13033775c259ddaae6a6fa8b26bd3262b34b9523a4fb3e5db3e9a60b2eb59R36-R44): Added a dead-letter queue `chatQueueDLQ` with a retention period of 14 days and configured the main `chatQueue` to use this DLQ with a maximum receive count of 2 (one retry).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
