### PR TITLE
feat: Ignore file not exists error when delete files in KB

### DIFF
--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -96,6 +96,9 @@ def _update_s3_documents_by_diff(
 
     for filename in deleted_filenames:
         document_path = compose_upload_document_s3_path(user_id, bot_id, filename)
+
+        # Ignore errors when deleting a non-existent file from the S3 bucket used in knowledge bases.
+        # This allows users to update bot if the uploaded file is missing after the bot is created.
         delete_file_from_s3(DOCUMENT_BUCKET, document_path, ignore_not_exist=True)
 
 
@@ -804,6 +807,8 @@ def issue_presigned_url(
 
 
 def remove_uploaded_file(user_id: str, bot_id: str, filename: str):
+    # Ignore errors when deleting a non-existent file from the S3 bucket used in knowledge bases.
+    # This allows users to update bot if the uploaded file is missing after the bot is created.
     delete_file_from_s3(
         DOCUMENT_BUCKET,
         compose_upload_temp_s3_path(user_id, bot_id, filename),

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -96,7 +96,7 @@ def _update_s3_documents_by_diff(
 
     for filename in deleted_filenames:
         document_path = compose_upload_document_s3_path(user_id, bot_id, filename)
-        delete_file_from_s3(DOCUMENT_BUCKET, document_path)
+        delete_file_from_s3(DOCUMENT_BUCKET, document_path, ignore_not_exist=True)
 
 
 def create_new_bot(user_id: str, bot_input: BotInput) -> BotOutput:
@@ -805,7 +805,9 @@ def issue_presigned_url(
 
 def remove_uploaded_file(user_id: str, bot_id: str, filename: str):
     delete_file_from_s3(
-        DOCUMENT_BUCKET, compose_upload_temp_s3_path(user_id, bot_id, filename)
+        DOCUMENT_BUCKET,
+        compose_upload_temp_s3_path(user_id, bot_id, filename),
+        ignore_not_exist=True,
     )
     return
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -92,17 +92,18 @@ def compose_upload_document_s3_path(user_id: str, bot_id: str, filename: str) ->
     return f"{user_id}/{bot_id}/documents/{filename}"
 
 
-def delete_file_from_s3(bucket: str, key: str):
+def delete_file_from_s3(bucket: str, key: str, ignore_not_exist: bool = False):
     client = boto3.client("s3", region_name=BEDROCK_REGION)
 
     # Check if the file exists
-    try:
-        client.head_object(Bucket=bucket, Key=key)
-    except ClientError as e:
-        if e.response["Error"]["Code"] == "404":
-            raise FileNotFoundError(f"The file does not exist in bucket.")
-        else:
-            raise
+    if not ignore_not_exist:
+        try:
+            client.head_object(Bucket=bucket, Key=key)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                raise FileNotFoundError(f"The file does not exist in bucket.")
+            else:
+                raise
 
     response = client.delete_object(Bucket=bucket, Key=key)
     return response


### PR DESCRIPTION
Closes #662

*Description of changes:*

Ignore `The file does not exist in bucket` error when deleting a file from S3 bucket for knowledge bases. This makes users to be able to update bot if the uploaded file has gone after bot created.

Rather than removing the check logic, I added a flag. If there is a reason why you raise this error intentionally, please let me know.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
