### PR TITLE
fix: Use npx for cdk command and remove bootstrap arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,28 +163,22 @@ cd cdk
 npm ci
 ```
 
-- Install [AWS CDK](https://aws.amazon.com/cdk/)
-
-```
-npm i -g aws-cdk
-```
-
-- Before deploying the CDK, you will need to work with Bootstrap once for the region you are deploying to. In this example, we will deploy to the us-east-1 region. Please replace your account id into `<account id>`.
-
-```
-cdk bootstrap aws://<account id>/us-east-1
-```
-
 - If necessary, edit the following entries in [cdk.json](./cdk/cdk.json) if necessary.
 
   - `bedrockRegion`: Region where Bedrock is available. **NOTE: Bedrock does NOT support all regions for now.**
   - `allowedIpV4AddressRanges`, `allowedIpV6AddressRanges`: Allowed IP Address range.
   - `enableLambdaSnapStart`: Defaults to true. Set to false if deploying to a [region that doesn't support Lambda SnapStart for Python functions](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-supported-regions).
 
+- Before deploying the CDK, you will need to work with Bootstrap once for the region you are deploying to.
+
+```
+npx cdk bootstrap
+```
+
 - Deploy this sample project
 
 ```
-cdk deploy --require-approval never --all
+npx cdk deploy --require-approval never --all
 ```
 
 - You will get output similar to the following. The URL of the web app will be output in `BedrockChatStack.FrontendURL`, so please access it from your browser.
@@ -205,7 +199,7 @@ BedrockChatStack.FrontendURL = https://xxxxx.cloudfront.net
 
 ### Configure Mistral models support
 
-Update `enableMistral` to `true` in [cdk.json](./cdk/cdk.json), and run `cdk deploy`.
+Update `enableMistral` to `true` in [cdk.json](./cdk/cdk.json), and run `npx cdk deploy`.
 
 ```json
 ...
@@ -231,7 +225,7 @@ DEFAULT_GENERATION_CONFIG = {
 
 ### Remove resources
 
-If using cli and CDK, please `cdk destroy`. If not, access [CloudFormation](https://console.aws.amazon.com/cloudformation/home) and then delete `BedrockChatStack` and `FrontendWafStack` manually. Please note that `FrontendWafStack` is in `us-east-1` region.
+If using cli and CDK, please `npx cdk destroy`. If not, access [CloudFormation](https://console.aws.amazon.com/cloudformation/home) and then delete `BedrockChatStack` and `FrontendWafStack` manually. Please note that `FrontendWafStack` is in `us-east-1` region.
 
 ### Language Settings
 

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -6,9 +6,9 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 ## Useful commands
 
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `cdk deploy`      deploy this stack to your default AWS account/region
-* `cdk diff`        compare deployed stack with current state
-* `cdk synth`       emits the synthesized CloudFormation template
+- `npm run build` compile typescript to js
+- `npm run watch` watch for changes and compile
+- `npm run test` perform the jest unit tests
+- `npx cdk deploy` deploy this stack to your default AWS account/region
+- `npx cdk diff` compare deployed stack with current state
+- `npx cdk synth` emits the synthesized CloudFormation template

--- a/cdk/lib/constructs/api-publish-codebuild.ts
+++ b/cdk/lib/constructs/api-publish-codebuild.ts
@@ -45,7 +45,6 @@ export class ApiPublishCodebuild extends Construct {
             "runtime-versions": {
               nodejs: "18",
             },
-            commands: ["npm install -g aws-cdk"],
             "on-failure": "ABORT",
           },
           build: {
@@ -54,7 +53,7 @@ export class ApiPublishCodebuild extends Construct {
               "npm ci",
               // Replace cdk's entrypoint. This is a workaround to avoid the issue that cdk synthesize all stacks.
               "sed -i 's|bin/bedrock-chat.ts|bin/api-publish.ts|' cdk.json",
-              `cdk deploy --require-approval never ApiPublishmentStack$PUBLISHED_API_ID \\
+              `npx cdk deploy --require-approval never ApiPublishmentStack$PUBLISHED_API_ID \\
          -c publishedApiThrottleRateLimit=$PUBLISHED_API_THROTTLE_RATE_LIMIT \\
          -c publishedApiThrottleBurstLimit=$PUBLISHED_API_THROTTLE_BURST_LIMIT \\
          -c publishedApiQuotaLimit=$PUBLISHED_API_QUOTA_LIMIT \\

--- a/cdk/lib/constructs/bedrock-custom-bot-codebuild.ts
+++ b/cdk/lib/constructs/bedrock-custom-bot-codebuild.ts
@@ -44,7 +44,6 @@ export class BedrockCustomBotCodebuild extends Construct {
             "runtime-versions": {
               nodejs: "18",
             },
-            commands: ["npm install -g aws-cdk"],
             "on-failure": "ABORT",
           },
           build: {
@@ -55,7 +54,7 @@ export class BedrockCustomBotCodebuild extends Construct {
               `export BOT_ID=$(echo $SK | awk -F'#' '{print $3}')`,
               // Replace cdk's entrypoint. This is a workaround to avoid the issue that cdk synthesize all stacks.
               "sed -i 's|bin/bedrock-chat.ts|bin/bedrock-custom-bot.ts|' cdk.json",
-              `cdk deploy --require-approval never BrChatKbStack$BOT_ID`,
+              `npx cdk deploy --require-approval never BrChatKbStack$BOT_ID`,
             ],
           },
         },

--- a/deploy.yml
+++ b/deploy.yml
@@ -143,9 +143,6 @@ Resources:
                 "runtime-versions": {
                   "nodejs": "18"
                 },
-                "commands": [
-                  "npm i -g aws-cdk"
-                ],
                 "on-failure": "ABORT"
               },
               "build": {
@@ -161,8 +158,8 @@ Resources:
                   "sed -i \"s/\\\"bedrockRegion\\\": \\\"[^\\\"]*\\\"/\\\"bedrockRegion\\\": \\\"${BEDROCK_REGION}\\\"/\" cdk/cdk.json",
                   "cd cdk",
                   "npm ci",
-                  "cdk bootstrap",
-                  "cdk deploy --require-approval never --all"
+                  "npx cdk bootstrap",
+                  "npx cdk deploy --require-approval never --all"
                 ]
               }
             }

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -61,7 +61,7 @@ To develop your own custom tools for the Agent, follow these guidelines:
   - Edit i18n files. Open [en/index.ts](../frontend/src/i18n/en/index.ts) and add your own `name` and `description` on `agent.tools`.
   - Edit `xx/index.ts` as well. Where `xx` represents the country code you wish.
 
-- Run `cdk deploy` to deploy your changes. This will make your custom tool available in the custom bot screen.
+- Run `npx cdk deploy` to deploy your changes. This will make your custom tool available in the custom bot screen.
 
 ## Contribution
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -6,11 +6,11 @@ See [backend/README](../backend/README.md).
 
 ## Frontend Development
 
-In this sample, you can locally modify and launch the frontend using AWS resources (`API Gateway`, `Cognito`, etc.) that have been deployed with `cdk deploy`.
+In this sample, you can locally modify and launch the frontend using AWS resources (`API Gateway`, `Cognito`, etc.) that have been deployed with `npx cdk deploy`.
 
 1. Refer to [Deploy using CDK](../README.md#deploy-using-cdk) for deploying on the AWS environment.
 2. Copy the `frontend/.env.template` and save it as `frontend/.env.local`.
-3. Fill in the contents of `.env.local` based on the output results of `cdk deploy` (such as `BedrockChatStack.AuthUserPoolClientIdXXXXX`).
+3. Fill in the contents of `.env.local` based on the output results of `npx cdk deploy` (such as `BedrockChatStack.AuthUserPoolClientIdXXXXX`).
 4. Execute the following command:
 
 ```zsh

--- a/docs/LOCAL_DEVELOPMENT_ja.md
+++ b/docs/LOCAL_DEVELOPMENT_ja.md
@@ -6,11 +6,11 @@
 
 ## フロントエンド
 
-現在このサンプルでは、`cdk deploy` された AWS リソース（API Gateway、Cognito など）を使用してローカルでフロントを立ち上げながら改変作業を加えることができます。
+現在このサンプルでは、`npx cdk deploy` された AWS リソース（API Gateway、Cognito など）を使用してローカルでフロントを立ち上げながら改変作業を加えることができます。
 
 1. [Deploy using CDK](./README_ja.md#deploy-using-cdk) を参考に AWS 環境上にデプロイを行う
 2. `frontend/.env.template` 複製し `frontend/.env.local` という名前で保存する。
-3. `.env.local` の中身を `cdk deploy` の出力結果（`BedrockChatStack.AuthUserPoolClientIdXXXXX` など）を見ながら穴埋めしていく
+3. `.env.local` の中身を `npx cdk deploy` の出力結果（`BedrockChatStack.AuthUserPoolClientIdXXXXX` など）を見ながら穴埋めしていく
 4. 下記コマンドを実行する
 
 ```zsh
@@ -19,5 +19,5 @@ cd frontend && npm ci && npm run dev
 
 ### ストリーミングの利用
 
-現在、環境変数として `VITE_APP_USE_STREAMING` というのをフロントエンド側で指定しています。バックエンドをローカルで動かす場合は `false` に指定してただき、AWS で動かす場合は `true` にすることを推奨します。  
+現在、環境変数として `VITE_APP_USE_STREAMING` というのをフロントエンド側で指定しています。バックエンドをローカルで動かす場合は `false` に指定してただき、AWS で動かす場合は `true` にすることを推奨します。
 Streaming を有効化すると文章生成結果がストリーミングされるためリアルタイムで文字列が生成されていきます。

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -1,7 +1,6 @@
 # Bedrock Claude Chat (Nova)
 
-> [!Warning]
-> **V2 がリリースされました。** 更新する際は、[移行ガイド](./migration/V1_TO_V2.md)を必ずご確認ください。 **注意を払わずに進めると、V1 の BOT は使用できなくなります。**
+> [!Warning] > **V2 がリリースされました。** 更新する際は、[移行ガイド](./migration/V1_TO_V2.md)を必ずご確認ください。 **注意を払わずに進めると、V1 の BOT は使用できなくなります。**
 
 このリポジトリは、生成系 AI を提供する[Amazon Bedrock](https://aws.amazon.com/jp/bedrock/)の基盤モデルの一つである、Anthropic 社製 LLM [Claude](https://www.anthropic.com/)を利用したチャットボットのサンプルです。
 
@@ -130,28 +129,22 @@ cd cdk
 npm ci
 ```
 
-- [AWS CDK](https://aws.amazon.com/jp/cdk/)をインストールします
-
-```
-npm i -g aws-cdk
-```
-
-- CDK デプロイ前に、デプロイ先リージョンに対して 1 度だけ Bootstrap の作業が必要となります。ここでは東京リージョンへデプロイするものとします。なお`<account id>`はアカウント ID に置換してください。
-
-```
-cdk bootstrap aws://<account id>/ap-northeast-1
-```
-
 - 必要に応じて[cdk.json](../cdk/cdk.json)の下記項目を編集します
 
   - `bedrockRegion`: Bedrock が利用できるリージョン
   - `allowedIpV4AddressRanges`, `allowedIpV6AddressRanges`: 許可する IP アドレス範囲の指定
   - `enableLambdaSnapStart`: デフォルトでは true ですが、[Python 関数の Lambda SnapStart をサポートしていないリージョン](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-supported-regions)にデプロイする場合は false に変更してください。
 
+- CDK デプロイ前に、1 度だけ Bootstrap の作業が必要となります。
+
+```
+npx cdk bootstrap
+```
+
 - プロジェクトをデプロイします
 
 ```
-cdk deploy --require-approval never --all
+npx cdk deploy --require-approval never --all
 ```
 
 - 下記のような出力が得られれば成功です。`BedrockChatStack.FrontendURL`に WEB アプリの URL が出力されますので、ブラウザからアクセスしてください。
@@ -172,7 +165,7 @@ BedrockChatStack.FrontendURL = https://xxxxx.cloudfront.net
 
 ### Mistral を利用する
 
-cdk.json 内の`enableMistral`を`true`に更新し、`cdk deploy`を実行します。
+cdk.json 内の`enableMistral`を`true`に更新し、`npx cdk deploy`を実行します。
 
 ```json
 ...
@@ -184,7 +177,7 @@ cdk.json 内の`enableMistral`を`true`に更新し、`cdk deploy`を実行し�
 
 ### テキスト生成パラメータの設定
 
-[config.py](../backend/app/config.py)を編集後、`cdk deploy`を実行してください。
+[config.py](../backend/app/config.py)を編集後、`npx cdk deploy`を実行してください。
 
 ```py
 GENERATION_CONFIG = {
@@ -206,7 +199,7 @@ GENERATION_CONFIG = {
 
 ### リソースの削除
 
-cli および CDK を利用されている場合、`cdk destroy`を実行してください。そうでない場合は[CloudFormation](https://console.aws.amazon.com/cloudformation/home)へアクセスし、手動で`BedrockChatStack`および`FrontendWafStack`を削除してください。なお`FrontendWafStack`は `us-east-1` リージョンにあります。
+cli および CDK を利用されている場合、`npx cdk destroy`を実行してください。そうでない場合は[CloudFormation](https://console.aws.amazon.com/cloudformation/home)へアクセスし、手動で`BedrockChatStack`および`FrontendWafStack`を削除してください。なお`FrontendWafStack`は `us-east-1` リージョンにあります。
 
 ### 言語設定について
 

--- a/docs/idp/SET_UP_CUSTOM_OIDC.md
+++ b/docs/idp/SET_UP_CUSTOM_OIDC.md
@@ -55,7 +55,7 @@ The `userPoolDomainPrefix` must be globally unique across all Amazon Cognito use
 Deploy your CDK stack to AWS:
 
 ```sh
-cdk deploy --require-approval never --all
+npx cdk deploy --require-approval never --all
 ```
 
 ## Step 5: Update OIDC Client with Cognito Redirect URIs

--- a/docs/idp/SET_UP_GOOGLE.md
+++ b/docs/idp/SET_UP_GOOGLE.md
@@ -61,7 +61,7 @@ The userPoolDomainPrefix must be globally unique across all Amazon Cognito users
 Deploy your CDK stack to AWS:
 
 ```sh
-cdk deploy --require-approval never --all
+npx cdk deploy --require-approval never --all
 ```
 
 ## Step 5: Update Google OAuth Client with Cognito Redirect URIs

--- a/docs/idp/SET_UP_GOOGLE_ja.md
+++ b/docs/idp/SET_UP_GOOGLE_ja.md
@@ -61,7 +61,7 @@ userPoolDomainPrefix は、すべての Amazon Cognito ユーザー間でグロ�
 AWS に CDK スタックをデプロイします：
 
 ```sh
-cdk deploy --require-approval never --all
+npx cdk deploy --require-approval never --all
 ```
 
 ## ステップ 5: Cognito リダイレクト URI で Google OAuth クライアントを更新する

--- a/docs/migration/DATABASE_MIGRATION.md
+++ b/docs/migration/DATABASE_MIGRATION.md
@@ -8,7 +8,7 @@ The migration process involves scanning all bots and launching embedding ECS tas
 
 ## Migration Steps
 
-- After [cdk deploy](../README.md#deploy-using-cdk) with Aurora replacement, open the [migrate.py](./migrate.py) script and update the following variables with the appropriate values. The values can be referred on `CloudFormation` > `BedrockChatStack` > `Outputs` tab.
+- After [npx cdk deploy](../README.md#deploy-using-cdk) with Aurora replacement, open the [migrate.py](./migrate.py) script and update the following variables with the appropriate values. The values can be referred on `CloudFormation` > `BedrockChatStack` > `Outputs` tab.
 
 ```py
 # Open the CloudFormation stack in the AWS Management Console and copy the values from the Outputs tab.
@@ -35,7 +35,7 @@ If you prefer not to use the above method due to the associated time and cost im
 
 ### Snapshot Restore and DMS Migration
 
-Firstly, note the password to access current Aurora cluster. Then run `cdk deploy`, which triggers replacement of the cluster. After that, create a temporary database by restoring from a snapshot of the original database.
+Firstly, note the password to access current Aurora cluster. Then run `npx cdk deploy`, which triggers replacement of the cluster. After that, create a temporary database by restoring from a snapshot of the original database.
 Use [AWS Database Migration Service (DMS)](https://aws.amazon.com/dms/) to migrate data from the temporary database to the new Aurora cluster.
 
 Note: As of May 29, 2024, DMS does not natively support the pgvector extension. However, you can explore the following options to work around this limitation:

--- a/docs/migration/V0_TO_V1.md
+++ b/docs/migration/V0_TO_V1.md
@@ -28,7 +28,7 @@ git pull origin v1
 
 - If you wish to restore items with DMS, DO NOT FORGET to disable password rotation and note the password to access the database. If restoring with the migration script([migrate.py](./migrate.py)), you don't need to note the password.
 - Remove all [published APIs](../PUBLISH_API.md) so that CloudFormation can remove existing Aurora cluster.
-- Run [cdk deploy](../README.md#deploy-using-cdk) triggers Aurora cluster replacement and DELETES ALL VECTOR ITEMS.
+- Run [npx cdk deploy](../README.md#deploy-using-cdk) triggers Aurora cluster replacement and DELETES ALL VECTOR ITEMS.
 - Follow [Database Migration Guide](./DATABASE_MIGRATION.md) to restore vector items.
 - Verify that user can utilize existing bots who have knowledge i.e. RAG bots.
 

--- a/docs/migration/V1_TO_V2.md
+++ b/docs/migration/V1_TO_V2.md
@@ -64,7 +64,7 @@ The steps differ depending on whether you are using v1.2 or earlier, or v1.3.
       ```
    3. Deploy the changes:
       ```bash
-      cdk deploy
+      npx cdk deploy
       ```
 
 3. **Recrate your bots**: Recreate your bots on Knowledge Base with the same definitions (documents, chunk size, etc.) as the pgvector bots. If you have a large volume of documents, restoring from the backup in step 1 will make this process easier. To restore, we can use restoring cross-region copies. For more detail, visit [here](https://docs.aws.amazon.com/aws-backup/latest/devguide/restoring-s3.html). To specify the restored bucket, set `S3 Data Source` section as following. The path structure is `s3://<bucket-name>/<user-id>/<bot-id>/documents/`. You can check user id on Cognito user pool and bot id on address bar on bot creation screen.
@@ -79,7 +79,7 @@ The steps differ depending on whether you are using v1.2 or earlier, or v1.3.
    ```bash
    git fetch --tags
    git checkout tags/v2.0.0
-   cdk deploy
+   npx cdk deploy
    ```
 
 > [!Warning]

--- a/examples/agents/tools/bmi/README.md
+++ b/examples/agents/tools/bmi/README.md
@@ -24,4 +24,4 @@ def get_available_tools() -> list[BaseTool]:
     return tools
 ```
 
-- Run cdk deploy.
+- Run `npx cdk deploy`.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Use `npx cdk` instead of `cdk`. Instead of using the CDK CLI of the latest version installed globally by `npm i -g aws-cdk`,
 use CDK CLI of the version explicitly specified in the project to avoid unexpected behavior.

Also, calling bootstrap without arguments can prevent users from forgetting to specify an environment and experiencing an error. CDK synthesizes the app and automatically bootstraps all environments included in it.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
