### PR TITLE
Enable cross-region inference for backend api

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -38,6 +38,11 @@ def get_bedrock_runtime_client(region=BEDROCK_REGION):
 
 
 def get_bedrock_agent_client(region=BEDROCK_REGION):
+    client = boto3.client("bedrock-agent", region_name=region)
+    return client
+
+
+def get_bedrock_agent_runtime_client(region=BEDROCK_REGION):
     client = boto3.client("bedrock-agent-runtime", region_name=region)
     return client
 

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -7,18 +7,15 @@ from app.repositories.models.conversation import (
     TextToolResultModel,
 )
 from app.repositories.models.custom_bot import BotModel
-from app.utils import get_bedrock_agent_client
-
+from app.utils import get_bedrock_agent_runtime_client
 from botocore.exceptions import ClientError
-from mypy_boto3_bedrock_runtime.type_defs import (
-    GuardrailConverseContentBlockTypeDef,
-)
 from mypy_boto3_bedrock_agent_runtime.type_defs import (
     KnowledgeBaseRetrievalResultTypeDef,
 )
+from mypy_boto3_bedrock_runtime.type_defs import GuardrailConverseContentBlockTypeDef
 
 logger = logging.getLogger(__name__)
-agent_client = get_bedrock_agent_client()
+agent_client = get_bedrock_agent_runtime_client()
 
 
 class SearchResult(TypedDict):

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -166,6 +166,8 @@ export class BedrockChatStack extends cdk.Stack {
       usageAnalysis,
       largeMessageBucket,
       enableMistral: props.enableMistral,
+      enableBedrockCrossRegionInference:
+        props.enableBedrockCrossRegionInference,
       enableLambdaSnapStart: props.enableLambdaSnapStart,
     });
     props.documentBucket.grantReadWrite(backendApi.handler);

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -38,6 +38,7 @@ export interface ApiProps {
   readonly bedrockCustomBotProject: codebuild.IProject;
   readonly usageAnalysis?: UsageAnalysis;
   readonly enableMistral: boolean;
+  readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
 }
 
@@ -206,12 +207,16 @@ export class Api extends Construct {
         USAGE_ANALYSIS_WORKGROUP: props.usageAnalysis?.workgroupName || "",
         USAGE_ANALYSIS_OUTPUT_LOCATION: usageAnalysisOutputLocation,
         ENABLE_MISTRAL: props.enableMistral.toString(),
+        ENABLE_BEDROCK_CROSS_REGION_INFERENCE:
+          props.enableBedrockCrossRegionInference.toString(),
         AWS_LAMBDA_EXEC_WRAPPER: "/opt/bootstrap",
         PORT: "8000",
       },
       role: handlerRole,
       logRetention: logs.RetentionDays.THREE_MONTHS,
-      snapStart: props.enableLambdaSnapStart ? SnapStartConf.ON_PUBLISHED_VERSIONS : undefined,
+      snapStart: props.enableLambdaSnapStart
+        ? SnapStartConf.ON_PUBLISHED_VERSIONS
+        : undefined,
       layers: [
         LayerVersion.fromLayerVersionArn(
           this,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enable cross-region inference for backend api
  - Title suggestion uses backend api. If CRI not supported, it might cause throttling error
- Implement `get_bedrock_agent_client`
  - `bedrock-agent` and `bedrock-agent-runtime` are different boto3 client. So implemented explicitly for future maintenance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
