### PR TITLE
Fix: merge existing knowledge base configuration when modifying bot

### DIFF
--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -347,6 +347,23 @@ def modify_owned_bot(
         else "SUCCEEDED"
     )
 
+    # Use the existing knowledge base (KB) configuration if available, as it may have been set externally
+    # by a Step Functions state machine for embedding processes e.g. data source id. If a new KB configuration is provided,
+    # merge it with the existing one; otherwise, retain the current KB settings.
+    current_bot_kb = bot.bedrock_knowledge_base
+    if modify_input.bedrock_knowledge_base:
+        updated_kb = (
+            current_bot_kb.model_copy(
+                update=modify_input.bedrock_knowledge_base.model_dump()
+            )
+            if current_bot_kb
+            else BedrockKnowledgeBaseModel(
+                **modify_input.bedrock_knowledge_base.model_dump()
+            )
+        )
+    else:
+        updated_kb = current_bot_kb
+
     update_bot(
         user_id,
         bot_id,
@@ -375,13 +392,7 @@ def modify_owned_bot(
                 for starter in modify_input.conversation_quick_starters
             ]
         ),
-        bedrock_knowledge_base=(
-            BedrockKnowledgeBaseModel(
-                **modify_input.bedrock_knowledge_base.model_dump()
-            )
-            if modify_input.bedrock_knowledge_base
-            else None
-        ),
+        bedrock_knowledge_base=updated_kb,
         bedrock_guardrails=(
             BedrockGuardrailsModel(**modify_input.bedrock_guardrails.model_dump())
             if modify_input.bedrock_guardrails

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -351,6 +351,7 @@ def modify_owned_bot(
     # by a Step Functions state machine for embedding processes e.g. data source id. If a new KB configuration is provided,
     # merge it with the existing one; otherwise, retain the current KB settings.
     current_bot_kb = bot.bedrock_knowledge_base
+    updated_kb: BedrockKnowledgeBaseModel | None = None
     if modify_input.bedrock_knowledge_base:
         updated_kb = (
             current_bot_kb.model_copy(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR merges existing kb configuration and kb input provided when the bot is updated. This is because `DataSourceId` is set via the embedding process ([source](https://github.com/aws-samples/bedrock-claude-chat/blob/v2/backend/embedding_statemachine/bedrock_knowledge_base/store_knowledge_base_id.py#L44-L53)), so we need to merge it when updating the bot. Currently, there's no problem because the application does not use the stored DataSourceIds explicitly, but we fix it for future maintenance.

Note that current behavior is: data source ids set to null when update the bot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
