### PR TITLE
Support Alternate Domain in cloudfront by adding domain in hosted zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,28 @@ This is an account/region-level setting, affecting the entire application rather
 "enableLambdaSnapStart": false
 ```
 
+### Configure Custom Domain
+
+You can configure a custom domain for the CloudFront distribution by setting the following parameters in [cdk.json](./cdk/cdk.json):
+
+```json
+{
+  "alternateDomainName": "chat.example.com",
+  "hostedZoneId": "Z0123456789ABCDEF"
+}
+```
+
+- `alternateDomainName`: The custom domain name for your chat application (e.g., chat.example.com)
+- `hostedZoneId`: The ID of your Route 53 hosted zone where the domain records will be created
+
+When these parameters are provided, the deployment will automatically:
+- Create an ACM certificate with DNS validation in us-east-1 region
+- Create the necessary DNS records in your Route 53 hosted zone
+- Configure CloudFront to use your custom domain
+
+> [!Note]
+> The domain must be managed by Route 53 in your AWS account. The hosted zone ID can be found in the Route 53 console.
+
 ### Local Development
 
 See [LOCAL DEVELOPMENT](./docs/LOCAL_DEVELOPMENT.md).
@@ -327,3 +349,4 @@ Please also take a look at the following guidelines before contributing:
 ## License
 
 This library is licensed under the MIT-0 License. See [the LICENSE file](./LICENSE).
+

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -73,6 +73,9 @@ const bedrockRegionResources = new BedrockRegionResourcesStack(
   }
 );
 
+const ALTERNATE_DOMAIN_NAME: string = app.node.tryGetContext("alternateDomainName");
+const HOSTED_ZONE_ID: string = app.node.tryGetContext("hostedZoneId");
+
 const chat = new BedrockChatStack(app, `BedrockChatStack`, {
   env: {
     // account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -96,6 +99,8 @@ const chat = new BedrockChatStack(app, `BedrockChatStack`, {
   useStandbyReplicas: USE_STAND_BY_REPLICAS,
   enableBedrockCrossRegionInference: ENABLE_BEDROCK_CROSS_REGION_INFERENCE,
   enableLambdaSnapStart: ENABLE_LAMBDA_SNAPSTART,
+  alternateDomainName: ALTERNATE_DOMAIN_NAME,
+  hostedZoneId: HOSTED_ZONE_ID,
 });
 chat.addDependency(waf);
 chat.addDependency(bedrockRegionResources);

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -70,6 +70,8 @@
     ],
     "enableRagReplicas": true,
     "enableBedrockCrossRegionInference": true,
-    "enableLambdaSnapStart": true
+    "enableLambdaSnapStart": true,
+    "alternateDomainName": "",
+    "hostedZoneId": ""
   }
 }

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -40,6 +40,8 @@ export interface BedrockChatStackProps extends StackProps {
   readonly useStandbyReplicas: boolean;
   readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
+  readonly alternateDomainName?: string;
+  readonly hostedZoneId?: string;
 }
 
 export class BedrockChatStack extends cdk.Stack {
@@ -124,6 +126,8 @@ export class BedrockChatStack extends cdk.Stack {
       webAclId: props.webAclId,
       enableMistral: props.enableMistral,
       enableIpV6: props.enableIpV6,
+      alternateDomainName: props.alternateDomainName,
+      hostedZoneId: props.hostedZoneId,
     });
 
     const auth = new Auth(this, "Auth", {

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -280,6 +280,60 @@ describe("Bedrock Chat Stack Test", () => {
       HostedZoneId: "Z0123456789ABCDEF",
     });
   });
+
+  test("no custom domain configuration", () => {
+    const app = new cdk.App();
+    
+    const bedrockRegionResourcesStack = new BedrockRegionResourcesStack(
+      app,
+      "BedrockRegionResourcesStack",
+      {
+        env: {
+          region: "us-east-1",
+        },
+        crossRegionReferences: true,
+      }
+    );
+
+    const noDomainStack = new BedrockChatStack(app, "NoDomainStack", {
+      env: {
+        region: "us-east-1",
+      },
+      bedrockRegion: "us-east-1",
+      crossRegionReferences: true,
+      webAclId: "",
+      identityProviders: [],
+      userPoolDomainPrefix: "",
+      publishedApiAllowedIpV4AddressRanges: [""],
+      publishedApiAllowedIpV6AddressRanges: [""],
+      allowedSignUpEmailDomains: [],
+      autoJoinUserGroups: [],
+      enableMistral: false,
+      selfSignUpEnabled: true,
+      enableIpV6: true,
+      documentBucket: bedrockRegionResourcesStack.documentBucket,
+      useStandbyReplicas: false,
+      enableBedrockCrossRegionInference: false,
+      enableLambdaSnapStart: true,
+      alternateDomainName: "",
+      hostedZoneId: "",
+    });
+
+    const template = Template.fromStack(noDomainStack);
+
+    // Verify no Route53 records are created
+    template.resourceCountIs("AWS::Route53::RecordSet", 0);
+    
+    // Verify no ACM certificate is created
+    template.resourceCountIs("AWS::CertificateManager::Certificate", 0);
+
+    // Verify CloudFront distribution has no aliases
+    template.hasResourceProperties("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        Aliases: Match.absent(),
+      },
+    });
+  });
 });
 
 describe("Bedrock Knowledge Base Stack", () => {


### PR DESCRIPTION
Support Alternate Domain in cloudfront by adding domain in hosted zone and generate certificate for tls 

* Issue #689 *

*Description of changes:*
1. Add configuration to provide alternate domain in AWS Cloudfront
2. Modify frontend.ts code to configure the newly provided domain name in AWS Cloudfront and associate a certificate.
    - Create the provided record in the hosted zone
    - Generate a certificate for the newly created domain with DNS Challenge

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
