### PR TITLE
[fix] Fixed a bug where guardrails couldn't be used

### DIFF
--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -51,7 +51,7 @@ def handler(event, context):
     logger.info(f"Event: {event}")
     pk = event["pk"]
     sk = event["sk"]
-    stack_output: List[StackOutput] = event["stack_output"]
+    stack_output: StackOutput = event["stack_output"]
 
     # Check if stack_output is valid and has at least one item
     if (

--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -25,14 +25,14 @@ class Items(TypedDict):
 class StackOutput(TypedDict):
     """
     'stack_output': {
-        'KnowledgeBaseId': 'ABCDEFGHIJKL', 
+        'KnowledgeBaseId': 'ABCDEFGHIJKL',
         'items': [
             {
-                'KnowledgeBaseId': 'MNOPQRSTUVWX', 
-                'DataSourceId': 'YZABCDEFGHI', 
-                'GuardrailArn': 'arn:aws:bedrock:us-east-1:123456789012:guardrail/abcdefghijkl', 
-                'GuardrailVersion': 'DRAFT', 
-                'PK': '7801e3f0-40b1-70da-2e13-652d4adce1c3', 
+                'KnowledgeBaseId': 'MNOPQRSTUVWX',
+                'DataSourceId': 'YZABCDEFGHI',
+                'GuardrailArn': 'arn:aws:bedrock:us-east-1:123456789012:guardrail/abcdefghijkl',
+                'GuardrailVersion': 'DRAFT',
+                'PK': '7801e3f0-40b1-70da-2e13-652d4adce1c3',
                 'SK': '7801e3f0-40b1-70da-2e13-652d4adce1c3#BOT#01JKWE8RP6YWNX9SKFSCCNS73Z'
             }
         ]

--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -13,9 +13,18 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-class StackOutput(TypedDict):
+class Items(TypedDict):
+    KnowledgeBaseId: str
+    DataSourceId: str
     GuardrailArn: str
     GuardrailVersion: str
+    PK: str
+    SK: str
+
+
+class StackOutput(TypedDict):
+    KnowledgeBaseId: str
+    items: List[Items]
 
 
 def handler(event, context):
@@ -25,7 +34,11 @@ def handler(event, context):
     stack_output: List[StackOutput] = event["stack_output"]
 
     # Check if stack_output is valid and has at least one item
-    if not stack_output or not isinstance(stack_output["items"], list) or len(stack_output["items"]) == 0:
+    if (
+        not stack_output
+        or not isinstance(stack_output["items"], list)
+        or len(stack_output["items"]) == 0
+    ):
         logger.warning("Empty or invalid stack_output received")
         guardrail_arn = ""
         guardrail_version = ""

--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -24,22 +24,18 @@ class Items(TypedDict):
 
 class StackOutput(TypedDict):
     """
-    Expected format of StackOutput is here.
-    "StackOutput": {
-        "ExecutedVersion": "$LATEST",
-        "Payload": {
-            "KnowledgeBaseId": "7DTSQBTEXN",
-            "items": [
-                {
-                "KnowledgeBaseId": "7DTSQBTEXN",
-                "DataSourceId": "NNR3AV4TIY",
-                "GuardrailArn": "arn:aws:bedrock:us-east-1:241231359358:guardrail/z1x9stwgfepa",
-                "GuardrailVersion": "DRAFT",
-                "PK": "7801e3f0-40b1-70da-2e13-652d4adce1c3",
-                "SK": "7801e3f0-40b1-70da-2e13-652d4adce1c3#BOT#01JKWE8RP6YWNX9SKFSCCNS73Z"
-                }
-            ]
-        }
+    'stack_output': {
+        'KnowledgeBaseId': 'ABCDEFGHIJKL', 
+        'items': [
+            {
+                'KnowledgeBaseId': 'MNOPQRSTUVWX', 
+                'DataSourceId': 'YZABCDEFGHI', 
+                'GuardrailArn': 'arn:aws:bedrock:us-east-1:123456789012:guardrail/abcdefghijkl', 
+                'GuardrailVersion': 'DRAFT', 
+                'PK': '7801e3f0-40b1-70da-2e13-652d4adce1c3', 
+                'SK': '7801e3f0-40b1-70da-2e13-652d4adce1c3#BOT#01JKWE8RP6YWNX9SKFSCCNS73Z'
+            }
+        ]
     }
     """
 

--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -23,6 +23,26 @@ class Items(TypedDict):
 
 
 class StackOutput(TypedDict):
+    """
+    Expected format of StackOutput is here.
+    "StackOutput": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+            "KnowledgeBaseId": "7DTSQBTEXN",
+            "items": [
+                {
+                "KnowledgeBaseId": "7DTSQBTEXN",
+                "DataSourceId": "NNR3AV4TIY",
+                "GuardrailArn": "arn:aws:bedrock:us-east-1:241231359358:guardrail/z1x9stwgfepa",
+                "GuardrailVersion": "DRAFT",
+                "PK": "7801e3f0-40b1-70da-2e13-652d4adce1c3",
+                "SK": "7801e3f0-40b1-70da-2e13-652d4adce1c3#BOT#01JKWE8RP6YWNX9SKFSCCNS73Z"
+                }
+            ]
+        }
+    }
+    """
+
     KnowledgeBaseId: str
     items: List[Items]
 

--- a/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
+++ b/backend/embedding_statemachine/guardrails/store_guardrail_arn.py
@@ -25,13 +25,13 @@ def handler(event, context):
     stack_output: List[StackOutput] = event["stack_output"]
 
     # Check if stack_output is valid and has at least one item
-    if not stack_output or not isinstance(stack_output, list) or len(stack_output) == 0:
+    if not stack_output or not isinstance(stack_output["items"], list) or len(stack_output["items"]) == 0:
         logger.warning("Empty or invalid stack_output received")
         guardrail_arn = ""
         guardrail_version = ""
     else:
         # Access the first item directly since we know it exists
-        first_output = stack_output[0]
+        first_output = stack_output["items"][0]
         guardrail_arn = first_output.get("GuardrailArn", "")
         guardrail_version = first_output.get("GuardrailVersion", "")
 


### PR DESCRIPTION
*Issue #, if available:*
#661 

*Description of changes:*
The guardrail ARN and version were not recorded in DynamoDB.

Expected format of `StackOutput` is here. It needs `items`.
```
'stack_output': {
        'KnowledgeBaseId': 'ABCDEFGHIJKL', 
        'items': [
            {
                'KnowledgeBaseId': 'MNOPQRSTUVWX', 
                'DataSourceId': 'YZABCDEFGHI', 
                'GuardrailArn': 'arn:aws:bedrock:us-east-1:123456789012:guardrail/abcdefghijkl', 
                'GuardrailVersion': 'DRAFT', 
                'PK': '7801e3f0-40b1-70da-2e13-652d4adce1c3', 
                'SK': '7801e3f0-40b1-70da-2e13-652d4adce1c3#BOT#01JKWE8RP6YWNX9SKFSCCNS73Z'
            }
        ]
    }
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
