### PR TITLE
Fix: hard code GA timeout

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   translate:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TIMEOUT_MINUTES }}
+    timeout-minutes: 360 # NOTE: cannot specify using env variable
     steps:
       # Check for existing auto-translate PR to avoid infinite loop
       - name: Check for existing auto-translate PR


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GitHub Actions cannot recognize env vars on meta section, so hard code the timeout.  
Related: #729 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
