### PR TITLE
feat: Add support for query breakdown functionality for knowledge base retrieval

### DIFF
--- a/backend/app/agents/tools/knowledge.py
+++ b/backend/app/agents/tools/knowledge.py
@@ -13,7 +13,9 @@ logger.setLevel(logging.INFO)
 
 
 class KnowledgeToolInput(BaseModel):
-    query: str = Field(description="A search string for querying the Amazon Bedrock Knowledge base.")
+    query: str = Field(
+        description="A search string for querying the Amazon Bedrock Knowledge base."
+    )
 
 
 def search_knowledge(

--- a/backend/app/agents/tools/knowledge.py
+++ b/backend/app/agents/tools/knowledge.py
@@ -14,7 +14,7 @@ logger.setLevel(logging.INFO)
 
 class KnowledgeToolInput(BaseModel):
     query: str = Field(
-        description="A search string for querying the Amazon Bedrock Knowledge base."
+        description="Input suitable for vector search, full text search, and hybrid search. When searching continuously, the query must be designed so that it does not overlap with past contexts."
     )
 
 

--- a/backend/app/agents/tools/knowledge.py
+++ b/backend/app/agents/tools/knowledge.py
@@ -9,10 +9,11 @@ from pydantic import BaseModel, Field
 
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class KnowledgeToolInput(BaseModel):
-    query: str = Field(description="User's original question string.")
+    query: str = Field(description="A search string for querying the Amazon Bedrock Knowledge base.")
 
 
 def search_knowledge(

--- a/backend/app/repositories/models/custom_bot.py
+++ b/backend/app/repositories/models/custom_bot.py
@@ -309,7 +309,8 @@ class BotModel(BaseModel):
         )
 
     def is_agent_enabled(self) -> bool:
-        return len(self.agent.tools) > 0
+        # Always consider agents active, even if they have a knowledge base
+        return len(self.agent.tools) > 0 or self.has_knowledge()
 
     def has_bedrock_knowledge_base(self) -> bool:
         return self.bedrock_knowledge_base is not None and (

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -258,6 +258,7 @@ def chat(
     search_results: list[SearchResult] = []
     if bot is not None:
         if bot.is_agent_enabled():
+            # If it have a knowledge base, always process it in agent mode 
             if bot.has_knowledge():
                 # Add knowledge tool
                 knowledge_tool = create_knowledge_tool(bot=bot)
@@ -267,51 +268,6 @@ def chat(
                 instructions.append(
                     get_prompt_to_cite_tool_results(
                         model=chat_input.message.model,
-                    )
-                )
-
-        elif bot.has_knowledge():
-            # Fetch most related documents from vector store
-            # NOTE: Currently embedding not support multi-modal. For now, use the last content.
-            content = conversation.message_map[user_msg_id].content[-1]
-            if isinstance(content, TextContentModel):
-                pseudo_tool_use_id = "new-message-assistant"
-
-                if on_thinking:
-                    on_thinking(
-                        {
-                            "tool_use_id": pseudo_tool_use_id,
-                            "name": "knowledge_base_tool",
-                            "input": {
-                                "query": content.body,
-                            },
-                        }
-                    )
-
-                search_results = search_related_docs(bot=bot, query=content.body)
-                logger.info(f"Search results from vector store: {search_results}")
-
-                if on_tool_result:
-                    on_tool_result(
-                        {
-                            "tool_use_id": pseudo_tool_use_id,
-                            "status": "success",
-                            "related_documents": [
-                                search_result_to_related_document(
-                                    search_result=result,
-                                    source_id_base=pseudo_tool_use_id,
-                                )
-                                for result in search_results
-                            ],
-                        }
-                    )
-
-                # Insert contexts to instruction
-                instructions.append(
-                    build_rag_prompt(
-                        search_results=search_results,
-                        model=chat_input.message.model,
-                        display_citation=display_citation,
                     )
                 )
 

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -258,7 +258,7 @@ def chat(
     search_results: list[SearchResult] = []
     if bot is not None:
         if bot.is_agent_enabled():
-            # If it have a knowledge base, always process it in agent mode 
+            # If it have a knowledge base, always process it in agent mode
             if bot.has_knowledge():
                 # Add knowledge tool
                 knowledge_tool = create_knowledge_tool(bot=bot)

--- a/frontend/src/features/knowledgeBase/constants/index.ts
+++ b/frontend/src/features/knowledgeBase/constants/index.ts
@@ -156,6 +156,6 @@ export const EDGE_SEARCH_PARAMS = {
 };
 
 export const DEFAULT_SEARCH_CONFIG: SearchParams = {
-  maxResults: 20,
+  maxResults: 5,
   searchType: 'hybrid',
 };


### PR DESCRIPTION
*Issue #, if available:*
close #749 

*Description of changes:*
Currently, the chat input content is set directly to the Knowledge Base query. With this implementation, generative AI will think and set appropriate queries based on past conversations.

The DEFAULT_SEARCH_CONFIG parameter was changed from 20 to 5.
Knowledge bases and internet searches require a lot of context, so continuing a conversation may exceed limits such as context windows.

![Screenshot 2025-03-05 at 16 11 10](https://github.com/user-attachments/assets/2d665914-6b43-4ad0-beb4-21119e89dc97)
![Screenshot 2025-03-05 at 16 12 17](https://github.com/user-attachments/assets/ad04b6b4-59a2-491f-9c6f-36666bcefa53)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
