### PR TITLE
fix: Existing knowledge bases containing 3rd party data sources are now supported

### DIFF
--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -105,6 +105,22 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
                 source_name = urlparse(url=uri).path.split("/")[-1]
                 return (source_name, uri)
 
+            elif location_type == "CONFLUENCE":
+                url = location.get("confluenceLocation", {}).get("url", "")
+                return (url, url) if url else None
+
+            elif location_type == "SALESFORCE":
+                url = location.get("salesforceLocation", {}).get("url", "")
+                return (url, url) if url else None
+
+            elif location_type == "SHAREPOINT":
+                url = location.get("sharePointLocation", {}).get("url", "")
+                return (url, url) if url else None
+
+            elif location_type == "KENDRA":
+                url = location.get("kendraDocumentLocation", {}).get("uri", "")
+                return (url, url) if url else None
+
             return None
 
         search_results = []


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Currently BrChat only supported “WEB” and “S3,” so BrChat doesn't have access to third-party datasets when using an existing knowledge base. 
With this update, it can use “Amazon Kendra,” “Confluence,” “Microsoft SharePoint,” and “Salesforce.” 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
