### PR TITLE
fix #768: prevent error when starred bot is not on recently used list

### DIFF
--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -371,6 +371,7 @@ def find_private_bots_by_user_id(
             description=item["Description"],
             is_public="PublicBotId" in item,
             sync_status=item["SyncStatus"],
+            has_knowledge=bool(item.get("HasKnowledge")),
             has_bedrock_knowledge_base=(
                 True if item.get("BedrockKnowledgeBase", None) else False
             ),
@@ -396,6 +397,7 @@ def find_private_bots_by_user_id(
                     description=item["Description"],
                     is_public="PublicBotId" in item,
                     sync_status=item["SyncStatus"],
+                    has_knowledge=bool(item.get("HasKnowledge")),
                     has_bedrock_knowledge_base=(
                         True if item.get("BedrockKnowledgeBase", None) else False
                     ),
@@ -789,6 +791,7 @@ async def find_public_bots_by_ids(bot_ids: list[str]) -> list[BotMetaWithStackIn
                     sync_status=item["SyncStatus"],
                     published_api_stack_name=item.get("ApiPublishmentStackName", None),
                     published_api_datetime=item.get("ApiPublishedDatetime", None),
+                    has_knowledge=bool(item.get("HasKnowledge")),
                     has_bedrock_knowledge_base=(
                         True if item.get("BedrockKnowledgeBase", None) else False
                     ),
@@ -832,6 +835,7 @@ def find_all_published_bots(
             sync_status=item["SyncStatus"],
             published_api_stack_name=item["ApiPublishmentStackName"],
             published_api_datetime=item.get("ApiPublishedDatetime", None),
+            has_knowledge=bool(item.get("HasKnowledge")),
             has_bedrock_knowledge_base=(
                 True if item.get("BedrockKnowledgeBase", None) else False
             ),

--- a/backend/app/repositories/models/custom_bot.py
+++ b/backend/app/repositories/models/custom_bot.py
@@ -348,6 +348,7 @@ class BotMeta(BaseModel):
     # This can be `False` if the bot is not owned by the user and original bot is removed.
     available: bool
     sync_status: type_sync_status
+    has_knowledge: bool
     has_bedrock_knowledge_base: bool
 
 

--- a/backend/app/usecases/bot.py
+++ b/backend/app/usecases/bot.py
@@ -502,6 +502,7 @@ def fetch_all_bots_by_user_id(
                     description=bot.description,
                     is_public=True,
                     sync_status=bot.sync_status,
+                    has_knowledge=bot.has_knowledge(),
                     has_bedrock_knowledge_base=bot.has_bedrock_knowledge_base(),
                 )
             except RecordNotFoundError:
@@ -520,6 +521,7 @@ def fetch_all_bots_by_user_id(
                     description="This item is no longer available",
                     is_public=False,
                     sync_status="ORIGINAL_NOT_FOUND",
+                    has_knowledge=False,
                     has_bedrock_knowledge_base=False,
                 )
 
@@ -573,6 +575,7 @@ def fetch_all_bots_by_user_id(
                     description=item["Description"],
                     is_public="PublicBotId" in item,
                     sync_status=item["SyncStatus"],
+                    has_knowledge=bool(item.get("HasKnowledge")),
                     has_bedrock_knowledge_base=(
                         True if item.get("BedrockKnowledgeBase", None) else False
                     ),
@@ -607,7 +610,7 @@ def fetch_all_bots(
 
     bot_metas = []
     for bot in bots:
-        if not bot.has_bedrock_knowledge_base:
+        if bot.has_knowledge and not bot.has_bedrock_knowledge_base:
             # Created bots under major version 1.4~, 2~ should have bedrock knowledge base.
             # If the bot does not have bedrock knowledge base,
             # it is not shown in the list.

--- a/frontend/src/hooks/useBot.ts
+++ b/frontend/src/hooks/useBot.ts
@@ -158,7 +158,7 @@ const useBot = (shouldAutoRefreshMyBots?: boolean) => {
       const idx = recentlyUsedBots?.findIndex((bot) => bot.id === botId) ?? -1;
       mutateRecentlyUsedBots(
         produce(recentlyUsedBots, (draft) => {
-          if (draft) {
+          if (draft && idx !== -1) {
             draft[idx].isPinned = isStarred;
           }
         }),
@@ -169,7 +169,7 @@ const useBot = (shouldAutoRefreshMyBots?: boolean) => {
 
       mutateStarredBots(
         produce(starredBots, (draft) => {
-          if (recentlyUsedBots && isStarred) {
+          if (recentlyUsedBots && isStarred && idx !== -1) {
             draft?.unshift({
               ...recentlyUsedBots[idx],
             });


### PR DESCRIPTION
*Issue #, if available:*
#768 

*Description of changes:*
- fix #768: prevent error when starred bot is not on recently used list
- make bot without KB appears in recently used list


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
