### PR TITLE
Change trriger condition for auto-translation

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -8,7 +8,7 @@ env:
   TIMEOUT_SECONDS: 21600
 
 on:
-  pull_request:
+  push:
     branches:
       - main
       - v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR modifies the Auto Translate Docs workflow to execute on push events (after PR merges) instead of on PR creation. This change resolves the issue where the assume_role step was failing during PR creation events due to security context limitations when accessing repository secrets.

Key changes:
- Changed trigger from pull_request to push targeting the same branches

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
