### PR TITLE
fix: Adding Claude 3.5 Sonnet to Parsing model options

### DIFF
--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -14,7 +14,7 @@ type_kb_chunking_strategy = Literal[
 type_kb_embeddings_model = Literal["titan_v2", "cohere_multilingual_v3"]
 type_kb_search_type = Literal["hybrid", "semantic"]
 type_kb_parsing_model = Literal[
-    "anthropic.claude-3-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"
+    "anthropic.claude-3-5-sonnet-v1", "anthropic.claude-3-haiku-v1", "disabled"
 ]
 type_kb_web_crawling_scope = Literal["DEFAULT", "HOST_ONLY", "SUBDOMAINS"]
 

--- a/backend/tests/test_repositories/test_custom_bot.py
+++ b/backend/tests/test_repositories/test_custom_bot.py
@@ -79,7 +79,7 @@ class TestCustomBotRepository(unittest.TestCase):
                     max_tokens=2000,
                     overlap_percentage=0,
                 ),
-                parsing_model="anthropic.claude-3-sonnet-v1",
+                parsing_model="anthropic.claude-3-5-sonnet-v1",
                 web_crawling_scope="DEFAULT",
             ),
             bedrock_guardrails=BedrockGuardrailsModel(

--- a/cdk/lib/utils/bedrock-knowledge-base-args.ts
+++ b/cdk/lib/utils/bedrock-knowledge-base-args.ts
@@ -45,8 +45,8 @@ export const getParsingModel = (
   parsingModel: string
 ): BedrockFoundationModel | undefined => {
   switch (parsingModel) {
-    case "anthropic.claude-3-sonnet-v1":
-      return BedrockFoundationModel.ANTHROPIC_CLAUDE_SONNET_V1_0;
+    case "anthropic.claude-3-5-sonnet-v1":
+      return BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_SONNET_V1_0;
     case "anthropic.claude-3-haiku-v1":
       return BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0;
     case "disabled":

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -298,8 +298,8 @@ const BotKbEditPage: React.FC = () => {
       description: t('knowledgeBaseSettings.parsingModel.none.hint'),
     },
     {
-      label: t('knowledgeBaseSettings.parsingModel.claude_3_sonnet_v1.label'),
-      value: 'anthropic.claude-3-sonnet-v1',
+      label: t('knowledgeBaseSettings.parsingModel.claude_3_5_sonnet_v1.label'),
+      value: 'anthropic.claude-3-5-sonnet-v1',
       description: t(
         'knowledgeBaseSettings.parsingModel.claude_3_sonnet_v1.hint'
       ),

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -301,7 +301,7 @@ const BotKbEditPage: React.FC = () => {
       label: t('knowledgeBaseSettings.parsingModel.claude_3_5_sonnet_v1.label'),
       value: 'anthropic.claude-3-5-sonnet-v1',
       description: t(
-        'knowledgeBaseSettings.parsingModel.claude_3_sonnet_v1.hint'
+        'knowledgeBaseSettings.parsingModel.claude_3_5_sonnet_v1.hint'
       ),
     },
     {

--- a/frontend/src/features/knowledgeBase/types/index.d.ts
+++ b/frontend/src/features/knowledgeBase/types/index.d.ts
@@ -13,9 +13,7 @@ export type BedrockKnowledgeBase = {
 
 export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
 
-export type ParsingModel = 'anthropic.claude-3-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
-
-export type ParsingModel = 'anthropic.claude-3-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
+export type ParsingModel = 'anthropic.claude-3-5-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
 
 export type ChunkingStrategy = 'default' | 'fixed_size' | 'hierarchical' | 'semantic' | 'none';
 

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -714,9 +714,9 @@ How would you categorize this email?`,
           label: 'Disabled',
           hint: 'No advanced parsing will be applied.',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Use Claude 3 Sonnet v1 for advanced document parsing.',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Use Claude 3.5 Sonnet v1 for advanced document parsing.',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/id/index.ts
+++ b/frontend/src/i18n/id/index.ts
@@ -686,9 +686,9 @@ const translation = {
           label: 'Dinonaktifkan',
           hint: 'Tidak ada parsing lanjutan yang akan diterapkan.',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Gunakan Claude 3 Sonnet v1 untuk parsing dokumen lanjutan.',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Gunakan Claude 3.5 Sonnet v1 untuk parsing dokumen lanjutan.',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -708,9 +708,9 @@ const translation = {
           label: 'なし',
           hint: 'ドキュメントの高度な解析機能は適用されません。',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Claude 3 Sonnet v1を使用してドキュメントの高度な解析を行います。',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Claude 3.5 Sonnet v1を使用してドキュメントの高度な解析を行います。',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/ms/index.ts
+++ b/frontend/src/i18n/ms/index.ts
@@ -680,9 +680,9 @@ const translation = {
           label: 'Dinonaktifkan',
           hint: 'Tiada penguraian lanjutan akan diterapkan.',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Gunakan Claude 3 Sonnet v1 untuk penguraian dokumen lanjutan.',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Gunakan Claude 3.5 Sonnet v1 untuk penguraian dokumen lanjutan.',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -687,8 +687,8 @@ Jak sklasyfikowałbyś ten e-mail?`,
           hint: 'Zaawansowane parsowanie nie będzie stosowane.'
         },
         claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Użyj Claude 3 Sonnet v1 do zaawansowanego parsowania dokumentów.'
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Użyj Claude 3.5 Sonnet v1 do zaawansowanego parsowania dokumentów.'
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -686,7 +686,7 @@ Jak sklasyfikowałbyś ten e-mail?`,
           label: 'Wyłączone',
           hint: 'Zaawansowane parsowanie nie będzie stosowane.'
         },
-        claude_3_sonnet_v1: {
+        claude_3_5_sonnet_v1: {
           label: 'Claude 3.5 Sonnet v1',
           hint: 'Użyj Claude 3.5 Sonnet v1 do zaawansowanego parsowania dokumentów.'
         },

--- a/frontend/src/i18n/th/index.ts
+++ b/frontend/src/i18n/th/index.ts
@@ -676,9 +676,9 @@ const translation = {
           label: 'ปิดใช้งาน',
           hint: 'จะไม่ใช้การวิเคราะห์ขั้นสูง',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'ใช้ Claude 3 Sonnet v1 สำหรับการวิเคราะห์เอกสารขั้นสูง',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'ใช้ Claude 3.5 Sonnet v1 สำหรับการวิเคราะห์เอกสารขั้นสูง',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',

--- a/frontend/src/i18n/vi/index.ts
+++ b/frontend/src/i18n/vi/index.ts
@@ -688,9 +688,9 @@ Bạn sẽ phân loại email này như thế nào?`,
           label: 'Tắt',
           hint: 'Không áp dụng phân tích nâng cao.',
         },
-        claude_3_sonnet_v1: {
-          label: 'Claude 3 Sonnet v1',
-          hint: 'Sử dụng Claude 3 Sonnet v1 cho phân tích tài liệu nâng cao.',
+        claude_3_5_sonnet_v1: {
+          label: 'Claude 3.5 Sonnet v1',
+          hint: 'Sử dụng Claude 3.5 Sonnet v1 cho phân tích tài liệu nâng cao.',
         },
         claude_3_haiku_v1: {
           label: 'Claude 3 Haiku v1',


### PR DESCRIPTION
*Issue #, if available:*
#747 

*Description of changes:*
Refactor the parsing model.
Claude3 Sonnet was deprecated at the parsing model. It should be use claude 3.5 sonnet v1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
