### PR TITLE
feat: Make it possible to quickly jump to the corresponding page in the relevant document.

### DIFF
--- a/backend/app/agents/tools/agent_tool.py
+++ b/backend/app/agents/tools/agent_tool.py
@@ -137,6 +137,7 @@ def _function_result_to_related_document(
             content=TextToolResultModel(text=res),
             source_id=source_id,
             source_name=tool_name,
+            page_number=None,
         )
 
     elif isinstance(res, dict):
@@ -144,6 +145,8 @@ def _function_result_to_related_document(
         source_id_from_result = res.get("source_id")
         source_name = res.get("source_name")
         source_link = res.get("source_link")
+        page_number = res.get("page_number")
+        
         return RelatedDocumentModel(
             content=(
                 TextToolResultModel(
@@ -161,6 +164,7 @@ def _function_result_to_related_document(
             ),
             source_name=str(source_name) if source_name is not None else tool_name,
             source_link=str(source_link) if source_link is not None else None,
+            page_number=int(page_number) if page_number is not None else None,
         )
 
     else:
@@ -168,4 +172,5 @@ def _function_result_to_related_document(
             content=res,
             source_id=source_id,
             source_name=tool_name,
+            page_number=None,
         )

--- a/backend/app/agents/tools/agent_tool.py
+++ b/backend/app/agents/tools/agent_tool.py
@@ -146,7 +146,7 @@ def _function_result_to_related_document(
         source_name = res.get("source_name")
         source_link = res.get("source_link")
         page_number = res.get("page_number")
-        
+
         return RelatedDocumentModel(
             content=(
                 TextToolResultModel(

--- a/backend/app/repositories/conversation.py
+++ b/backend/app/repositories/conversation.py
@@ -348,6 +348,8 @@ def store_related_documents(
                 "SourceLink": related_document.source_link,
                 "Content": related_document.content.model_dump(by_alias=True),
             }
+            if related_document.page_number is not None:
+                item_params["PageNumber"] = related_document.page_number
             writer.put_item(Item=item_params)
 
 
@@ -382,6 +384,7 @@ def find_related_documents_by_conversation_id(
                 source_id=decompose_related_document_source_id(composed_id=item["SK"]),
                 source_name=item["SourceName"],
                 source_link=item["SourceLink"],
+                page_number=item.get("PageNumber"),
             )
             for item in response.get("Items") or []
         )
@@ -422,6 +425,7 @@ def find_related_document_by_id(
         source_id=source_id,
         source_name=item["SourceName"],
         source_link=item["SourceLink"],
+        page_number=item.get("PageNumber"),
     )
 
 

--- a/backend/app/repositories/models/conversation.py
+++ b/backend/app/repositories/models/conversation.py
@@ -711,6 +711,7 @@ class RelatedDocumentModel(BaseModel):
     source_id: str
     source_name: str | None = None
     source_link: str | None = None
+    page_number: int | None = None
 
     def to_tool_result_model(self, display_citation: bool) -> ToolResultModel:
         if isinstance(self.content, TextToolResultModel):
@@ -763,4 +764,5 @@ class RelatedDocumentModel(BaseModel):
             source_id=self.source_id,
             source_name=self.source_name,
             source_link=self.get_source_link_for_schema(),
+            page_number=self.page_number,
         )

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -201,6 +201,7 @@ class RelatedDocument(BaseSchema):
     source_id: str
     source_name: str | None = None
     source_link: str | None = None
+    page_number: int | None = None
 
 
 class ConversationMetaOutput(BaseSchema):

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -40,7 +40,7 @@ def search_result_to_related_document(
         source_id=f"{source_id_base}@{search_result['rank']}",
         source_name=search_result["source_name"],
         source_link=search_result["source_link"],
-        page_number=search_result["page_number"]
+        page_number=search_result["page_number"],
     )
 
 
@@ -138,7 +138,9 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
                 page_number = None
                 if "x-amz-bedrock-kb-document-page-number" in metadata:
                     try:
-                        page_number = int(metadata["x-amz-bedrock-kb-document-page-number"])
+                        page_number = int(
+                            metadata["x-amz-bedrock-kb-document-page-number"]
+                        )
                     except (ValueError, TypeError):
                         pass
 
@@ -150,7 +152,7 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
                         source_name=source[0],
                         source_link=source[1],
                         metadata=metadata,
-                        page_number=page_number
+                        page_number=page_number,
                     )
                 )
 

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -133,7 +133,7 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
             source = extract_source_from_retrieval_result(retrieval_result)
 
             if source is not None:
-                # ページ番号を取得
+                # get page number from metadata
                 metadata = retrieval_result.get("metadata", {})
                 page_number = None
                 if "x-amz-bedrock-kb-document-page-number" in metadata:

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TypedDict
+from typing import TypedDict, Any
 from urllib.parse import urlparse
 
 from app.repositories.models.conversation import (
@@ -15,6 +15,7 @@ from mypy_boto3_bedrock_agent_runtime.type_defs import (
 from mypy_boto3_bedrock_runtime.type_defs import GuardrailConverseContentBlockTypeDef
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 agent_client = get_bedrock_agent_runtime_client()
 
 
@@ -24,6 +25,8 @@ class SearchResult(TypedDict):
     source_name: str
     source_link: str
     rank: int
+    metadata: dict[str, Any]
+    page_number: int | None
 
 
 def search_result_to_related_document(
@@ -37,6 +40,7 @@ def search_result_to_related_document(
         source_id=f"{source_id_base}@{search_result['rank']}",
         source_name=search_result["source_name"],
         source_link=search_result["source_link"],
+        page_number=search_result["page_number"]
     )
 
 
@@ -129,6 +133,15 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
             source = extract_source_from_retrieval_result(retrieval_result)
 
             if source is not None:
+                # ページ番号を取得
+                metadata = retrieval_result.get("metadata", {})
+                page_number = None
+                if "x-amz-bedrock-kb-document-page-number" in metadata:
+                    try:
+                        page_number = int(metadata["x-amz-bedrock-kb-document-page-number"])
+                    except (ValueError, TypeError):
+                        pass
+
                 search_results.append(
                     SearchResult(
                         rank=i,
@@ -136,6 +149,8 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
                         content=content,
                         source_name=source[0],
                         source_link=source[1],
+                        metadata=metadata,
+                        page_number=page_number
                     )
                 )
 

--- a/backend/tests/test_usecases/test_chat.py
+++ b/backend/tests/test_usecases/test_chat.py
@@ -1042,6 +1042,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 0,
+                "page_number": None
             },
             {
                 "bot_id": "bot_bb                    ",
@@ -1049,6 +1050,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 1,
+                "page_number": None
             },
             {
                 "bot_id": "bot_bb                    ",
@@ -1056,6 +1058,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 2,
+                "page_number": None
             },
         ]
         instruction = build_rag_prompt(

--- a/backend/tests/test_usecases/test_chat.py
+++ b/backend/tests/test_usecases/test_chat.py
@@ -1042,7 +1042,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 0,
-                "page_number": None
+                "page_number": None,
             },
             {
                 "bot_id": "bot_bb                    ",
@@ -1050,7 +1050,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 1,
-                "page_number": None
+                "page_number": None,
             },
             {
                 "bot_id": "bot_bb                    ",
@@ -1058,7 +1058,7 @@ class TestInsertKnowledge(unittest.TestCase):
                 "source_name": "AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "source_link": "https://pages.awscloud.com/rs/112-TZM-766/images/AWS-Black-Belt_2023_AmazonOpenSearchServerless_0131_v1.pdf",
                 "rank": 2,
-                "page_number": None
+                "page_number": None,
             },
         ]
         instruction = build_rag_prompt(

--- a/frontend/src/@types/conversation.d.ts
+++ b/frontend/src/@types/conversation.d.ts
@@ -100,6 +100,7 @@ export type RelatedDocument = {
   sourceId: string;
   sourceName?: string;
   sourceLink?: string;
+  pageNumber?: number;
 };
 
 export type DisplayMessageContent = MessageContent & {

--- a/frontend/src/components/RelatedDocumentViewer.tsx
+++ b/frontend/src/components/RelatedDocumentViewer.tsx
@@ -16,7 +16,7 @@ const RelatedDocumentViewer: React.FC<{
   ), [props.relatedDocument.content]);
 
   const sourceName = useMemo(() => {
-    if (!props.relatedDocument.sourceName) return undefined;
+    if (!props.relatedDocument.sourceName) {return undefined;}
     if (props.relatedDocument.pageNumber) {
       return `${props.relatedDocument.sourceName} (p.${props.relatedDocument.pageNumber})`;
     }
@@ -24,7 +24,7 @@ const RelatedDocumentViewer: React.FC<{
   }, [props.relatedDocument.sourceName, props.relatedDocument.pageNumber]);
 
   const sourceLink = useMemo(() => {
-    if (!props.relatedDocument.sourceLink) return undefined;
+    if (!props.relatedDocument.sourceLink) {return undefined;}
     if (props.relatedDocument.pageNumber) {
       return `${props.relatedDocument.sourceLink}#page=${props.relatedDocument.pageNumber}`;
     }

--- a/frontend/src/components/RelatedDocumentViewer.tsx
+++ b/frontend/src/components/RelatedDocumentViewer.tsx
@@ -15,13 +15,21 @@ const RelatedDocumentViewer: React.FC<{
     props.relatedDocument.content
   ), [props.relatedDocument.content]);
 
-  const sourceName = useMemo(() => (
-    props.relatedDocument.sourceName
-  ), [props.relatedDocument.sourceName]);
+  const sourceName = useMemo(() => {
+    if (!props.relatedDocument.sourceName) return undefined;
+    if (props.relatedDocument.pageNumber) {
+      return `${props.relatedDocument.sourceName} (p.${props.relatedDocument.pageNumber})`;
+    }
+    return props.relatedDocument.sourceName;
+  }, [props.relatedDocument.sourceName, props.relatedDocument.pageNumber]);
 
-  const sourceLink = useMemo(() => (
-    props.relatedDocument.sourceLink
-  ), [props.relatedDocument.sourceLink]);
+  const sourceLink = useMemo(() => {
+    if (!props.relatedDocument.sourceLink) return undefined;
+    if (props.relatedDocument.pageNumber) {
+      return `${props.relatedDocument.sourceLink}#page=${props.relatedDocument.pageNumber}`;
+    }
+    return props.relatedDocument.sourceLink;
+  }, [props.relatedDocument.sourceLink, props.relatedDocument.pageNumber]);
 
   return (
     <div


### PR DESCRIPTION
*Issue #, if available:*
#781 

*Description of changes:*
Knowledge Base has metadata including page numbers for PDF documents.
I have implemented a function that allows you to directly open the corresponding page by assigning a page number to the end of the S3 URL.

![Screenshot 2025-04-01 at 16 14 51](https://github.com/user-attachments/assets/9a6f6822-ed45-415a-8f00-1925b9457cb6)
![Screenshot 2025-04-01 at 16 15 06](https://github.com/user-attachments/assets/c194062f-9d1f-483c-af6c-615837eb6574)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
