### PR TITLE
Retain conversation table

### DIFF
--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -27,7 +27,7 @@ export class Database extends Construct {
       // SK: ConversationId | BotId
       sortKey: { name: "SK", type: AttributeType.STRING },
       billingMode: BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
+      removalPolicy: RemovalPolicy.RETAIN,
       stream: StreamViewType.NEW_IMAGE,
       pointInTimeRecovery: props?.pointInTimeRecovery,
       encryption: TableEncryption.AWS_MANAGED,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
To migrate v2 ConversationTable to v3 Tables, retain the v2 table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
