### PR TITLE
Allowing passing of existing certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ You can configure a custom domain for the CloudFront distribution by setting the
 
 - `alternateDomainName`: The custom domain name for your chat application (e.g., chat.example.com)
 - `hostedZoneId`: The ID of your Route 53 hosted zone where the domain records will be created
-- `certificateArn`: The arn of an existing certificate
+- `certificateArn`: The arn of an existing certificate to attach to a domain. 
 
 When these parameters are provided, the deployment will automatically:
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ You can configure a custom domain for the CloudFront distribution by setting the
 
 - `alternateDomainName`: The custom domain name for your chat application (e.g., chat.example.com)
 - `hostedZoneId`: The ID of your Route 53 hosted zone where the domain records will be created
-- `certificateArn`: The arn of an existing certificate to attach to a domain. 
+- `certificateArn`: The arn of an existing certificate to attach to a hosted domain. 
 
 When these parameters are provided, the deployment will automatically:
 

--- a/README.md
+++ b/README.md
@@ -527,12 +527,14 @@ You can configure a custom domain for the CloudFront distribution by setting the
 ```json
 {
   "alternateDomainName": "chat.example.com",
-  "hostedZoneId": "Z0123456789ABCDEF"
+  "hostedZoneId": "Z0123456789ABCDEF",
+  "certificateArn": "arn:aws:acm:us-east-1:<AWS_ACCOUNT_ID>:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
 }
 ```
 
 - `alternateDomainName`: The custom domain name for your chat application (e.g., chat.example.com)
 - `hostedZoneId`: The ID of your Route 53 hosted zone where the domain records will be created
+- `certificateArn`: The arn of an existing certificate
 
 When these parameters are provided, the deployment will automatically:
 

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -75,6 +75,7 @@
     "tokenValidMinutes": 30,
     "alternateDomainName": "",
     "hostedZoneId": "",
+    "certificateArn": "",
     "devAccessIamRoleArn": ""
   }
 }

--- a/cdk/lib/constructs/frontend.ts
+++ b/cdk/lib/constructs/frontend.ts
@@ -77,7 +77,6 @@ export class Frontend extends Construct {
           validation: acm.CertificateValidation.fromDns(this.hostedZone),
         });
       }
-      // inside your stack:
     }
 
     const distribution = new Distribution(this, "Distribution", {

--- a/cdk/lib/constructs/frontend.ts
+++ b/cdk/lib/constructs/frontend.ts
@@ -34,6 +34,7 @@ export interface FrontendProps {
    * Required if alternateDomainName is provided
    */
   readonly hostedZoneId?: string;
+  readonly certificateArn?: string;
 }
 
 export class Frontend extends Construct {
@@ -65,12 +66,18 @@ export class Frontend extends Construct {
         zoneName: this.getDomainZoneName(props.alternateDomainName),
       });
 
-      this.certificate = new acm.DnsValidatedCertificate(this, 'Certificate', {
-        domainName: props.alternateDomainName,
-        hostedZone: this.hostedZone,
-        region: 'us-east-1',
-        validation: acm.CertificateValidation.fromDns(this.hostedZone),
-      });
+      if (props.certificateArn){
+        this.certificate = acm.Certificate.fromCertificateArn(this, 'ImportedCertificate', props.certificateArn);
+      }
+      else{
+        this.certificate = new acm.DnsValidatedCertificate(this, 'Certificate', {
+          domainName: props.alternateDomainName,
+          hostedZone: this.hostedZone,
+          region: 'us-east-1',
+          validation: acm.CertificateValidation.fromDns(this.hostedZone),
+        });
+      }
+      // inside your stack:
     }
 
     const distribution = new Distribution(this, "Distribution", {

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -92,6 +92,7 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   // Custom domain configuration
   alternateDomainName: z.string().default(""),
   hostedZoneId: z.string().default(""),
+  certificateArn: z.string().default(""),
 
   // BotStore
   enableBotStore: z.boolean().default(true),
@@ -221,6 +222,7 @@ export function resolveBedrockChatParameters(
     enableLambdaSnapStart: app.node.tryGetContext("enableLambdaSnapStart"),
     alternateDomainName: app.node.tryGetContext("alternateDomainName"),
     hostedZoneId: app.node.tryGetContext("hostedZoneId"),
+    certificateArn: app.node.tryGetContext("certificateArn"),
     enableBotStore: app.node.tryGetContext("enableBotStore"),
     botStoreLanguage: app.node.tryGetContext("botStoreLanguage"),
     devAccessIamRoleArn: app.node.tryGetContext("devAccessIamRoleArn"),


### PR DESCRIPTION
The following changes allow an existing certificate to be applied to an alternate domain by adding the certificate ARN to the cdk.json file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
