### PR TITLE
fix: Drop unsigned reasoning content for DeepSeek R1

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -266,7 +266,11 @@ def compose_args_for_converse_api(
 ) -> ConverseStreamRequestTypeDef:
     def process_content(c: ContentModel, role: str) -> list[ContentBlockTypeDef]:
         # Drop unsigned reasoning blocks only for DeepSeek R1
-        if is_deepseek_model(model) and c.content_type == "reasoning" and not getattr(c, "signature", None):
+        if (
+            is_deepseek_model(model)
+            and c.content_type == "reasoning"
+            and not getattr(c, "signature", None)
+        ):
             return []
 
         if c.content_type == "text":

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -265,6 +265,10 @@ def compose_args_for_converse_api(
     enable_reasoning: bool = False,
 ) -> ConverseStreamRequestTypeDef:
     def process_content(c: ContentModel, role: str) -> list[ContentBlockTypeDef]:
+        # Drop unsigned reasoning blocks only for DeepSeek R1
+        if is_deepseek_model(model) and c.content_type == "reasoning" and not getattr(c, "signature", None):
+            return []
+
         if c.content_type == "text":
             if (
                 role == "user"


### PR DESCRIPTION
*Issue https://github.com/aws-samples/bedrock-chat/issues/845*

*Description of changes:*

**Problem:** DeepSeek R1 emits `reasoningContent` blocks without a signature, causing a `ValidationException: User messages cannot contain reasoning content` on follow-up calls to `ConverseStream`.

**Cause:** AWS Bedrock requires every `reasoningContent` block in the request to include a valid signature. DeepSeek’s default responses omit that field, while other models (e.g. Claude 3.7) include it.

**Solution:** In `compose_args_for_converse_api`, update `process_content` so that only for DeepSeek R1 we drop any `reasoning` blocks that lack `signature`. This preserves reasoning for models that supply a signature and prevents the ValidationException for DeepSeek.

## Changes

- `bedrock.py`
```python

    def process_content(c: ContentModel, role: str) -> list[ContentBlockTypeDef]:
        # Drop unsigned reasoning blocks only for DeepSeek R1
        if (
            is_deepseek_model(model)
            and c.content_type == "reasoning"
            and not getattr(c, "signature", None)
        ):
            return []

        if c.content_type == "text":
```
## Testing

- Verified that follow-up prompts using DeepSeek R1 no longer trigger the ValidationException.
- Confirmed that Claude 3.7 and other models continue to stream reasoning blocks (with valid signatures) as before.

![image](https://github.com/user-attachments/assets/c31509cd-dc0d-4cb9-a919-c8ad38e537b2)

Reference: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
