### PR TITLE
Add the .env files to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 AmazonQ.md
 memory-bank
 .clinerules
+frontend/.env.*


### PR DESCRIPTION
Tiny change to help ensure that no secrets are accidentally leaked during development.


*Description of changes:*

Just adding `.env.*` to `gitignore`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
