### PR TITLE
fix: Lambda environment variables for API publishing

### DIFF
--- a/cdk/bin/api-publish.ts
+++ b/cdk/bin/api-publish.ts
@@ -42,6 +42,7 @@ new ApiPublishmentStack(app, `ApiPublishmentStack${params.publishedApiId}`, {
     region: process.env.CDK_DEFAULT_REGION,
   },
   bedrockRegion: params.bedrockRegion,
+  enableBedrockCrossRegionInference: params.enableBedrockCrossRegionInference,
   conversationTableName: conversationTableName,
   botTableName: botTableName,
   tableAccessRoleArn: tableAccessRoleArn,

--- a/cdk/lib/api-publishment-stack.ts
+++ b/cdk/lib/api-publishment-stack.ts
@@ -15,6 +15,7 @@ import { excludeDockerImage } from "./constants/docker";
 
 interface ApiPublishmentStackProps extends StackProps {
   readonly bedrockRegion: string;
+  readonly enableBedrockCrossRegionInference: boolean;
   readonly conversationTableName: string;
   readonly botTableName: string;
   readonly tableAccessRoleArn: string;
@@ -129,6 +130,7 @@ export class ApiPublishmentStack extends Stack {
           ),
           ACCOUNT: Stack.of(this).account,
           REGION: Stack.of(this).region,
+          ENABLE_BEDROCK_CROSS_REGION_INFERENCE: props.enableBedrockCrossRegionInference.toString(),
           BEDROCK_REGION: props.bedrockRegion,
           TABLE_ACCESS_ROLE_ARN: props.tableAccessRoleArn,
         },

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -32,6 +32,7 @@ const BaseParametersSchema = z.object({
 
   // Bedrock configuration
   bedrockRegion: z.string().default("us-east-1"),
+  enableBedrockCrossRegionInference: z.boolean().default(true),
 });
 
 /**
@@ -49,8 +50,6 @@ function getEnvVar(name: string, defaultValue?: string): string | undefined {
  * Parameters schema for the main Bedrock Chat application
  */
 const BedrockChatParametersSchema = BaseParametersSchema.extend({
-  // Bedrock configuration
-  enableBedrockCrossRegionInference: z.boolean().default(true),
 
   // IP address restrictions
   allowedIpV4AddressRanges: z
@@ -286,6 +285,9 @@ export function resolveApiPublishParameters(): ApiPublishParameters {
     envName: getEnvVar("ENV_NAME"),
     envPrefix: getEnvVar("ENV_PREFIX"),
     bedrockRegion: getEnvVar("BEDROCK_REGION"),
+    enableBedrockCrossRegionInference: getEnvVar(
+      "ENABLE_BEDROCK_CROSS_REGION_INFERENCE"
+    ),
     publishedApiThrottleRateLimit: getEnvVar(
       "PUBLISHED_API_THROTTLE_RATE_LIMIT"
     ),


### PR DESCRIPTION
*Issue #, if available:*
#771 
#752 

*Description of changes:*
When using the API publish function, models supported only by cross-region reference could not be executed.
Fixed an issue where Bedrock's cross-region reference settings were not included in the Lambda environment variables for API publishing.

[error log]
```
[ERROR]	2025-05-14T02:08:26.043Z	85e9ea8b-1d8c-5571-96ac-8a16e0c8017f	Error: An error occurred (ValidationException) when calling the ConverseStream operation: Invocation of model ID amazon.nova-pro-v1:0 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
