### PR TITLE
Replace retry package with reretry on v2-v3 migration script

### DIFF
--- a/docs/migration/migrate_v2_v3.py
+++ b/docs/migration/migrate_v2_v3.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import boto3
 from boto3.dynamodb.conditions import Attr, Key
 from botocore.exceptions import ClientError
-from retry import retry
+from reretry import retry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("migration")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
#860 fixes CVE issue by replacing `retry` with `reretry`, but the v2-v3 migration script still uses `retry`. This PR fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
