### PR TITLE
fix: prevent automatic KaTeX formatting for $...$ inline math in chat messages

### DIFF
--- a/frontend/src/components/ChatMessageMarkdown.tsx
+++ b/frontend/src/components/ChatMessageMarkdown.tsx
@@ -115,6 +115,17 @@ const ChatMessageMarkdown: React.FC<Props> = ({
       },
     );
 
+    // Simple approach: only allow $$ for math, escape single $ that are not part of valid math
+    // This regex looks for $ that are not followed by another $ and not preceded by another $
+    // Examples:
+    // - "$5.99" becomes "\$5.99" (not processed as math)
+    // - "$x + y$" becomes "\$x + y\$" (not processed as math)
+    // - "$$x + y$$" stays "$$x + y$$" (processed as block math)
+    textReplacedSourceId = textReplacedSourceId.replace(
+      /(?<!\$)\$(?!\$)/g,
+      '\\$'
+    );
+
     if (isStreaming) {
       textReplacedSourceId += chatWaitingSymbol;
     }


### PR DESCRIPTION

*Issue #, if available:*
When the model includes dollar signs in its response, the UI automatically formats text as KaTeX. This is now fixed

*Description of changes:*
- Only process block math expressions with $$...$$ as KaTeX
- Escape single dollar signs ($) to avoid unwanted math rendering (e.g., for currency or variables)
- Improves user experience and prevents accidental math formatting in chat
- Update documentation with new math formatting behavior


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
