### PR TITLE
fix: strip citation tags when copying text

### DIFF
--- a/frontend/src/components/ButtonCopy.tsx
+++ b/frontend/src/components/ButtonCopy.tsx
@@ -12,7 +12,9 @@ const ButtonCopy: React.FC<Props> = (props) => {
   const [showsCheck, setshowsCheck] = useState(false);
 
   const copyMessage = useCallback((message: string) => {
-    copy(message);
+    // Strip out [^...] citation tags before copying
+    const cleanedText = message.replace(/\[\^[^\]]*\]/g, '');
+    copy(cleanedText);
     setshowsCheck(true);
 
     setTimeout(() => {


### PR DESCRIPTION
*Description of changes:*

Remove [^...] citation tags from copied text to provide cleaner content for pasting into other applications. The regex pattern /\[\^[^\]]*\]/g matches and removes all citation references while preserving the rest of the text content.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
