### PR TITLE
# 899 Omit overrideSearchType, when knowledge base resource contains …

### DIFF
--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -103,11 +103,17 @@ def store_bot(custom_bot: BotModel):
             else custom_bot.bedrock_knowledge_base.knowledge_base_id
         )
         # Get Knowledge Base from Bedrock Agent API :: get_knowledge_base
-        knowledge_base_info = get_knowledge_base_info(knowledge_base_id=knowledge_base_id)
+        knowledge_base_info = get_knowledge_base_info(
+            knowledge_base_id=knowledge_base_id
+        )
         # Get Knowledge Base Type from API Response
-        knowledge_base_type = knowledge_base_info.knowledge_base.knowledge_base_configuration.type
+        knowledge_base_type = (
+            knowledge_base_info.knowledge_base.knowledge_base_configuration.type
+        )
         # Set Knowledge Base Resource Type
-        custom_bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type = knowledge_base_type
+        custom_bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type = (
+            knowledge_base_type
+        )
         # Update Resource Info
         item["BedrockKnowledgeBase"] = custom_bot.bedrock_knowledge_base.model_dump()
     if custom_bot.bedrock_guardrails:

--- a/backend/app/repositories/custom_bot.py
+++ b/backend/app/repositories/custom_bot.py
@@ -16,7 +16,6 @@ from app.repositories.common import (
     get_bot_table_client,
     get_dynamodb_client,
 )
-from app.repositories.knowledge_base import get_knowledge_base_info
 from app.repositories.models.custom_bot import (
     ActiveModelsModel,
     AgentModel,
@@ -96,25 +95,6 @@ def store_bot(custom_bot: BotModel):
         # To use sparse index, set `IsStarred` attribute only when it's starred
         item["IsStarred"] = "TRUE"
     if custom_bot.bedrock_knowledge_base:
-        # Use exist_knowledge_base_id if available, otherwise use knowledge_base_id
-        knowledge_base_id = (
-            custom_bot.bedrock_knowledge_base.exist_knowledge_base_id
-            if custom_bot.bedrock_knowledge_base.exist_knowledge_base_id is not None
-            else custom_bot.bedrock_knowledge_base.knowledge_base_id
-        )
-        # Get Knowledge Base from Bedrock Agent API :: get_knowledge_base
-        knowledge_base_info = get_knowledge_base_info(
-            knowledge_base_id=knowledge_base_id
-        )
-        # Get Knowledge Base Type from API Response
-        knowledge_base_type = (
-            knowledge_base_info.knowledge_base.knowledge_base_configuration.type
-        )
-        # Set Knowledge Base Resource Type
-        custom_bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type = (
-            knowledge_base_type
-        )
-        # Update Resource Info
         item["BedrockKnowledgeBase"] = custom_bot.bedrock_knowledge_base.model_dump()
     if custom_bot.bedrock_guardrails:
         item["GuardrailsParams"] = custom_bot.bedrock_guardrails.model_dump()

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.DEBUG)
 
 
 def get_knowledge_base_info(
-    knowledge_base_id: str,
+    knowledge_base_id: str | None,
 ) -> BedrockAgentGetKnowledgeBaseResponse:
     client = get_bedrock_agent_client()
     try:

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -30,8 +30,6 @@ def get_knowledge_base_info(
         logger.error(f"Failed to get knowledge base info: {e}")
         return BedrockAgentGetKnowledgeBaseResponse(
             knowledge_base=KnowledgeBase(
-                knowledge_base_configuration=KnowledgeBaseConfiguration(
-                    type="VECTOR"
-                )
+                knowledge_base_configuration=KnowledgeBaseConfiguration(type="VECTOR")
             )
         )

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -1,0 +1,37 @@
+import logging
+
+from app.utils import get_bedrock_agent_client
+from app.repositories.models.custom_bot_kb import (
+    BedrockAgentGetKnowledgeBaseResponse,
+    KnowledgeBase,
+    KnowledgeBaseConfiguration,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def get_knowledge_base_info(
+    knowledge_base_id: str,
+) -> BedrockAgentGetKnowledgeBaseResponse:
+    client = get_bedrock_agent_client()
+    try:
+        response = client.get_knowledge_base(knowledgeBaseId=knowledge_base_id)
+        return BedrockAgentGetKnowledgeBaseResponse(
+            knowledge_base=KnowledgeBase(
+                knowledge_base_configuration=KnowledgeBaseConfiguration(
+                    type=response.get("knowledgeBase", {})
+                    .get("knowledgeBaseConfiguration", {})
+                    .get("type", "VECTOR")
+                )
+            )
+        )
+    except Exception as e:
+        logger.error(f"Failed to get knowledge base info: {e}")
+        return BedrockAgentGetKnowledgeBaseResponse(
+            knowledge_base=KnowledgeBase(
+                knowledge_base_configuration=KnowledgeBaseConfiguration(
+                    type="VECTOR"
+                )
+            )
+        )

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -16,7 +16,6 @@ from pydantic import BaseModel, validator, model_validator
 class SearchParamsModel(BaseModel):
     max_results: int
     search_type: type_kb_search_type
-    knowledge_base_resource_type: type_kb_resource_type | None = None
 
 
 class AnalyzerParamsModel(BaseModel):

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -7,6 +7,7 @@ from app.routes.schemas.bot_kb import (
     type_os_character_filter,
     type_os_token_filter,
     type_os_tokenizer,
+    type_kb_resource_type,
 )
 from typing import Self
 from pydantic import BaseModel, validator, model_validator
@@ -15,6 +16,7 @@ from pydantic import BaseModel, validator, model_validator
 class SearchParamsModel(BaseModel):
     max_results: int
     search_type: type_kb_search_type
+    knowledge_base_resource_type: type_kb_resource_type | None = None
 
 
 class AnalyzerParamsModel(BaseModel):
@@ -58,6 +60,18 @@ class NoneParamsModel(BaseModel):
 class WebCrawlingFiltersModel(BaseModel):
     exclude_patterns: list[str]
     include_patterns: list[str]
+
+
+class KnowledgeBaseConfiguration(BaseModel):
+    type: type_kb_resource_type = "VECTOR"
+
+
+class KnowledgeBase(BaseModel):
+    knowledge_base_configuration: KnowledgeBaseConfiguration
+
+
+class BedrockAgentGetKnowledgeBaseResponse(BaseModel):
+    knowledge_base: KnowledgeBase
 
 
 class BedrockKnowledgeBaseModel(BaseModel):

--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -62,7 +62,7 @@ class WebCrawlingFiltersModel(BaseModel):
 
 
 class KnowledgeBaseConfiguration(BaseModel):
-    type: type_kb_resource_type = "VECTOR"
+    type: type_kb_resource_type
 
 
 class KnowledgeBase(BaseModel):

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -35,10 +35,15 @@ type_os_token_filter = Literal[
     "icu_folding",
 ]
 
+# Knowledge Base Type
+# Ref: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_KnowledgeBaseConfiguration.html#bedrock-Type-agent_KnowledgeBaseConfiguration-type
+type_kb_resource_type = Literal["VECTOR", "KENDRA", "SQL"]
+
 
 class SearchParams(BaseSchema):
     max_results: int
     search_type: type_kb_search_type
+    knowledge_base_resource_type: str | None = None
 
 
 class AnalyzerParams(BaseSchema):

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -43,7 +43,6 @@ type_kb_resource_type = Literal["VECTOR", "KENDRA", "SQL"]
 class SearchParams(BaseSchema):
     max_results: int
     search_type: type_kb_search_type
-    knowledge_base_resource_type: str | None = None
 
 
 class AnalyzerParams(BaseSchema):

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -7,12 +7,19 @@ from app.repositories.models.conversation import (
     TextToolResultModel,
 )
 from app.repositories.models.custom_bot import BotModel
+from app.repositories.knowledge_base import get_knowledge_base_info
 from app.utils import get_bedrock_agent_runtime_client
 from botocore.exceptions import ClientError
 from mypy_boto3_bedrock_agent_runtime.type_defs import (
     KnowledgeBaseRetrievalResultTypeDef,
+    KnowledgeBaseVectorSearchConfigurationTypeDef,
+    RetrieveRequestTypeDef,
+)
+from mypy_boto3_bedrock_agent_runtime.literals import (
+    SearchTypeType,
 )
 from mypy_boto3_bedrock_runtime.type_defs import GuardrailConverseContentBlockTypeDef
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -67,6 +74,7 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
         or bot.bedrock_knowledge_base.exist_knowledge_base_id is not None
     ), "Either knowledge_base_id or exist_knowledge_base_id must be set"
 
+    search_type: SearchTypeType
     if bot.bedrock_knowledge_base.search_params.search_type == "semantic":
         search_type = "SEMANTIC"
     elif bot.bedrock_knowledge_base.search_params.search_type == "hybrid":
@@ -81,10 +89,11 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
         if bot.bedrock_knowledge_base.exist_knowledge_base_id is not None
         else bot.bedrock_knowledge_base.knowledge_base_id
     )
+    assert knowledge_base_id is not None, "knowledge_base_id must be set"
 
     try:
         # Init retrieve parameter
-        retrieve_parameter = {
+        retrieve_parameter: RetrieveRequestTypeDef = {
             "knowledgeBaseId": knowledge_base_id,
             "retrievalQuery": {"text": query},
             "retrievalConfiguration": {
@@ -96,39 +105,32 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
         }
 
         # Omit overrideSearchType parameter if needed
-        def omit_override_search_type_parameter(retrieve_parameter: dict):
-            keys = [
-                "retrievalConfiguration",
-                "vectorSearchConfiguration",
-            ]
-            target_parameter = retrieve_parameter
-            for key in keys:
-                target_parameter = target_parameter.get(key, {})
+        def omit_override_search_type_parameter(
+            retrieve_parameter: RetrieveRequestTypeDef,
+        ):
+            target_parameter: KnowledgeBaseVectorSearchConfigurationTypeDef = (
+                retrieve_parameter.get("retrievalConfiguration", {}).get(
+                    "vectorSearchConfiguration", {}
+                )
+            )
             # If overrideSearchType exists, remove it
             if "overrideSearchType" in target_parameter:
                 del target_parameter["overrideSearchType"]
 
+        # Get Knowledge Base from Bedrock Agent API :: get_knowledge_base
+        knowledge_base_info = get_knowledge_base_info(
+            knowledge_base_id=knowledge_base_id
+        )
         # Check the knowledge base resource type
         if (
-            bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type
+            knowledge_base_info.knowledge_base.knowledge_base_configuration.type
             == "KENDRA"
         ):
             # Omit overrideSearchType option when the type is "KENDRA"
             omit_override_search_type_parameter(retrieve_parameter)
 
-        try:
-            # Send retrieve request
-            response = agent_client.retrieve(**retrieve_parameter)
-        except ClientError as e:
-            # If error message contains "kendra"
-            if "kendra" in f"{e}".lower():
-                # Omit overrideSearchType option
-                omit_override_search_type_parameter(retrieve_parameter)
-                # Retry the retrieve request
-                response = agent_client.retrieve(**retrieve_parameter)
-            else:
-                # If other error occurs, raise
-                raise
+        # Send retrieve request
+        response = agent_client.retrieve(**retrieve_parameter)
 
         def extract_source_from_retrieval_result(
             retrieval_result: KnowledgeBaseRetrievalResultTypeDef,

--- a/backend/app/vector_search.py
+++ b/backend/app/vector_search.py
@@ -109,7 +109,10 @@ def _bedrock_knowledge_base_search(bot: BotModel, query: str) -> list[SearchResu
                 del target_parameter["overrideSearchType"]
 
         # Check the knowledge base resource type
-        if bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type == "KENDRA":
+        if (
+            bot.bedrock_knowledge_base.search_params.knowledge_base_resource_type
+            == "KENDRA"
+        ):
             # Omit overrideSearchType option when the type is "KENDRA"
             omit_override_search_type_parameter(retrieve_parameter)
 


### PR DESCRIPTION
*Issue #, if available:*

#899 [BUG] When Kendra is set up in the knowledge base, search processing hangs due to an error.

*Description of changes:*

Implemented the following actions:

1. When saving the bot, execute BedrockAgent::get_knowledge_base to retrieve the type of knowledge base.
Store the type in the searchParam of DynamoDB.

2. Before executing agent_client.retrieve, retrieve the type of knowledge base from the searchParam of DynamoDB.
If the knowledge base type is KENDRA, remove the overrideSearchType parameter and re-execute.

3. If there is an error during the execution of retrieve, determine whether the error message contains Kendra.
If Kendra is included, remove the overrideSearchType parameter and re-execute.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
