### PR TITLE
feat: Add Claude 4.1 Opus model support

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional, Literal, Tuple, TypeGuard
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, TypeGuard
 
 from app.config import (
     BEDROCK_PRICING,
@@ -88,6 +88,7 @@ def is_prompt_caching_supported(
     if target == "tool":
         return model in [
             "claude-v4-opus",
+            "claude-v4.1-opus",
             "claude-v4-sonnet",
             "claude-v3.7-sonnet",
             "claude-v3.5-sonnet-v2",
@@ -97,6 +98,7 @@ def is_prompt_caching_supported(
     else:
         return model in [
             "claude-v4-opus",
+            "claude-v4.1-opus",
             "claude-v4-sonnet",
             "claude-v3.7-sonnet",
             "claude-v3.5-sonnet-v2",
@@ -309,11 +311,7 @@ def compose_args_for_converse_api(
             ):
                 return [
                     {"guardContent": grounding_source},
-                    {
-                        "guardContent": {
-                            "text": {"text": c.body, "qualifiers": ["query"]}
-                        }
-                    },
+                    {"guardContent": {"text": {"text": c.body, "qualifiers": ["query"]}}},
                 ]
 
         return c.to_contents_for_converse()
@@ -393,8 +391,8 @@ def compose_args_for_converse_api(
 
     elif is_mistral(model):
         # Special handling for Mistral models
-        inference_config, additional_model_request_fields = (
-            _prepare_mistral_model_params(model, generation_params)
+        inference_config, additional_model_request_fields = _prepare_mistral_model_params(
+            model, generation_params
         )
         system_prompts = (
             [
@@ -576,9 +574,7 @@ def call_converse_api(
         return client.converse(**args)
     except ClientError as e:
         if e.response["Error"]["Code"] == "ThrottlingException":
-            raise BedrockThrottlingException(
-                "Bedrock API is throttling requests"
-            ) from e
+            raise BedrockThrottlingException("Bedrock API is throttling requests") from e
         raise
 
 
@@ -633,6 +629,7 @@ def get_model_id(
     # Ref: https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html
     base_model_ids = {
         "claude-v4-opus": "anthropic.claude-opus-4-20250514-v1:0",
+        "claude-v4.1-opus": "anthropic.claude-opus-4-1-20250805-v1:0",
         "claude-v4-sonnet": "anthropic.claude-sonnet-4-20250514-v1:0",
         "claude-v3-haiku": "anthropic.claude-3-haiku-20240307-v1:0",
         "claude-v3-opus": "anthropic.claude-3-opus-20240229-v1:0",
@@ -668,6 +665,7 @@ def get_model_id(
                 "amazon-nova-micro",
                 "amazon-nova-pro",
                 "claude-v4-opus",
+                "claude-v4.1-opus",
                 "claude-v4-sonnet",
                 "claude-v3-haiku",
                 "claude-v3-opus",
@@ -690,6 +688,7 @@ def get_model_id(
                 "amazon-nova-micro",
                 "amazon-nova-pro",
                 "claude-v4-opus",
+                "claude-v4.1-opus",
                 "claude-v4-sonnet",
                 "claude-v3-haiku",
                 "claude-v3.5-haiku",
@@ -711,6 +710,7 @@ def get_model_id(
                 "amazon-nova-micro",
                 "amazon-nova-pro",
                 "claude-v4-opus",
+                "claude-v4.1-opus",
                 "claude-v4-sonnet",
                 "claude-v3-haiku",
                 "claude-v3-opus",

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -311,7 +311,11 @@ def compose_args_for_converse_api(
             ):
                 return [
                     {"guardContent": grounding_source},
-                    {"guardContent": {"text": {"text": c.body, "qualifiers": ["query"]}}},
+                    {
+                        "guardContent": {
+                            "text": {"text": c.body, "qualifiers": ["query"]}
+                        }
+                    },
                 ]
 
         return c.to_contents_for_converse()
@@ -391,8 +395,8 @@ def compose_args_for_converse_api(
 
     elif is_mistral(model):
         # Special handling for Mistral models
-        inference_config, additional_model_request_fields = _prepare_mistral_model_params(
-            model, generation_params
+        inference_config, additional_model_request_fields = (
+            _prepare_mistral_model_params(model, generation_params)
         )
         system_prompts = (
             [
@@ -574,7 +578,9 @@ def call_converse_api(
         return client.converse(**args)
     except ClientError as e:
         if e.response["Error"]["Code"] == "ThrottlingException":
-            raise BedrockThrottlingException("Bedrock API is throttling requests") from e
+            raise BedrockThrottlingException(
+                "Bedrock API is throttling requests"
+            ) from e
         raise
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -69,6 +69,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.01875,
             "cache_read_input": 0.0015,
         },
+        "claude-v4.1-opus": {
+            "input": 0.015,
+            "output": 0.075,
+            "cache_write_input": 0.01875,
+            "cache_read_input": 0.0015,
+        },
         "claude-v4-sonnet": {
             "input": 0.003,
             "output": 0.015,
@@ -136,6 +142,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.01875,
             "cache_read_input": 0.0015,
         },
+        "claude-v4.1-opus": {
+            "input": 0.015,
+            "output": 0.075,
+            "cache_write_input": 0.01875,
+            "cache_read_input": 0.0015,
+        },
         "claude-v4-sonnet": {
             "input": 0.003,
             "output": 0.015,
@@ -182,6 +194,12 @@ BEDROCK_PRICING = {
     "ap-northeast-1": {},
     "default": {
         "claude-v4-opus": {
+            "input": 0.015,
+            "output": 0.075,
+            "cache_write_input": 0.01875,
+            "cache_read_input": 0.0015,
+        },
+        "claude-v4.1-opus": {
             "input": 0.015,
             "output": 0.075,
             "cache_write_input": 0.01875,

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -7,6 +7,7 @@ from pydantic import Discriminator, Field, JsonValue, root_validator
 
 type_model_name = Literal[
     "claude-v4-opus",
+    "claude-v4.1-opus",
     "claude-v4-sonnet",
     "claude-v3.5-sonnet",
     "claude-v3.5-sonnet-v2",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -83,6 +83,7 @@ export const GUARDRAILS_CONTECTUAL_GROUNDING_THRESHOLD = {
 
 export const AVAILABLE_MODEL_KEYS = [
   'claude-v4-opus',
+  'claude-v4.1-opus',
   'claude-v4-sonnet',
   'claude-v3-opus',
   'claude-v3.5-sonnet',

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -90,6 +90,13 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportReasoning: true,
       },
       {
+        modelId: 'claude-v4.1-opus',
+        label: t('model.claude-v4.1-opus.label'),
+        description: t('model.claude-v4.1-opus.description'),
+        supportMediaType: CLAUDE_SUPPORTED_MEDIA_TYPES,
+        supportReasoning: true,
+      },
+      {
         modelId: 'claude-v4-sonnet',
         label: t('model.claude-v4-sonnet.label'),
         description: t('model.claude-v4-sonnet.description'),

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -20,7 +20,12 @@ const translation = {
       'claude-v4-opus': {
         label: 'Claude 4 (Opus)',
         description:
-          'Most powerful hybrid reasoning model for complex tasks, coding, and AI agents with 200K token context window.',
+          'Powerful hybrid reasoning model for complex tasks, coding, and AI agents with 200K token context window.',
+      },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'Latest version of the most powerful Claude model with enhanced reasoning capabilities.',
       },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -35,6 +35,11 @@ const translation = {
         description:
           'La última versión, con una capacidad de respuesta aún más rápida y mejor rendimiento respecto a Haiku 3.',
       },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'La versión más reciente del modelo Claude más potente con capacidades de razonamiento mejoradas.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo potente para tareas altamente complejas.',

--- a/frontend/src/i18n/id/index.ts
+++ b/frontend/src/i18n/id/index.ts
@@ -35,6 +35,11 @@ const translation = {
         description:
           'Versi terbaru, menawarkan respons yang lebih cepat dan kemampuan yang ditingkatkan dibandingkan Haiku 3.',
       },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'Versi terbaru dari model Claude terkuat dengan kemampuan penalaran yang ditingkatkan.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Model yang kuat untuk tugas-tugas yang sangat kompleks.',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -23,7 +23,12 @@ const translation: typeof en = {
       'claude-v4-opus': {
         label: 'Claude 4 (Opus)',
         description:
-          '複雑なタスク、コーディング、AIエージェント向けの最も強力なハイブリッド推論モデル（200Kトークンコンテキストウィンドウ）',
+          '複雑なタスク、コーディング、AIエージェント向けの強力なハイブリッド推論モデル（200Kトークンコンテキストウィンドウ）',
+      },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          '最も強力なClaudeモデルの最新版。推論能力が向上',
       },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -35,6 +35,11 @@ const translation = {
         description:
           'Najnowsza wersja, oferująca jeszcze szybsze odpowiedzi i ulepszone możliwości w porównaniu do Haiku 3.',
       },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'Najnowsza wersja najsilniejszego modelu Claude z ulepszonymi możliwościami rozumowania.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Potężny model do wysoce złożonych zadań.',

--- a/frontend/src/i18n/pt-br/index.ts
+++ b/frontend/src/i18n/pt-br/index.ts
@@ -42,6 +42,11 @@ const translation = {
         description:
           'A versão mais recente, oferecendo respostas ainda mais rápidas e capacidades aprimoradas em relação ao Haiku 3.',
       },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'A versão mais recente do modelo Claude mais poderoso com capacidades de raciocínio aprimoradas.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo poderoso para tarefas altamente complexas.',

--- a/frontend/src/i18n/vi/index.ts
+++ b/frontend/src/i18n/vi/index.ts
@@ -35,6 +35,11 @@ const translation = {
         description:
           'Phiên bản mới nhất, phản hồi nhanh hơn và cải tiến khả năng so với Haiku 3.',
       },
+      'claude-v4.1-opus': {
+        label: 'Claude 4.1 (Opus)',
+        description:
+          'Phiên bản mới nhất của mô hình Claude mạnh nhất với khả năng lý luận được cải thiện.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Mô hình mạnh mẽ cho các tác vụ cực kỳ phức tạp.',


### PR DESCRIPTION
*Issue #, if available:*
close #905

*Description of changes:*
- Add model ID mapping for anthropic.claude-opus-4-1-20250805-v1:0
- Add model to type definitions and available models list
- Add pricing configuration (same as Claude 4 Opus)
- Add support for US regions: us-east-1, us-east-2, us-west-2
- Add prompt caching and reasoning support
- Add multi-language translations for all supported locales
- Update frontend model configuration with media type support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
