### PR TITLE
fix Allowed-Origins format, to support - in domain

### DIFF
--- a/frontend/src/pages/BotApiSettingsPage.tsx
+++ b/frontend/src/pages/BotApiSettingsPage.tsx
@@ -175,7 +175,7 @@ const BotApiSettingsPage: React.FC = () => {
         setErrorMessage(`origins${idx}`, t('input.validationError.required'));
         hasError = true;
       } else if (
-        !/^(https?:\/\/)?([a-zA-Z0-9\\-\\.*]+)(:(\d+))?$/.test(origin)
+        !/^(https?:\/\/)?([a-zA-Z0-9\-\.*]+)(:(\d+))?$/.test(origin)
       ) {
         setErrorMessage(
           `origins${idx}`,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix Allowed-Origins format, to support - in domain. Previously the example https://*.your-host-name.com will cause "Invalid Origin format" error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
