### PR TITLE
Fix: WAF IP restriction not working #776

### DIFF
--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -81,6 +81,8 @@ const chat = new BedrockChatStack(
       params.publishedApiAllowedIpV4AddressRanges,
     publishedApiAllowedIpV6AddressRanges:
       params.publishedApiAllowedIpV6AddressRanges,
+    allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+    allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
     allowedSignUpEmailDomains: params.allowedSignUpEmailDomains,
     autoJoinUserGroups: params.autoJoinUserGroups,
     selfSignUpEnabled: params.selfSignUpEnabled,

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -18,6 +18,7 @@ import { Embedding } from "./constructs/embedding";
 import { UsageAnalysis } from "./constructs/usage-analysis";
 import { TIdentityProvider, identityProvider } from "./utils/identity-provider";
 import { ApiPublishCodebuild } from "./constructs/api-publish-codebuild";
+import { WebAclForCognito } from "./constructs/webacl-for-cognito";
 import { WebAclForPublishedApi } from "./constructs/webacl-for-published-api";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import * as iam from "aws-cdk-lib/aws-iam";
@@ -36,6 +37,8 @@ export interface BedrockChatStackProps extends StackProps {
   readonly userPoolDomainPrefix: string;
   readonly publishedApiAllowedIpV4AddressRanges: string[];
   readonly publishedApiAllowedIpV6AddressRanges: string[];
+  readonly allowedIpV4AddressRanges: string[];
+  readonly allowedIpV6AddressRanges: string[];
   readonly allowedSignUpEmailDomains: string[];
   readonly autoJoinUserGroups: string[];
   readonly selfSignUpEnabled: boolean;
@@ -145,6 +148,19 @@ export class BedrockChatStack extends cdk.Stack {
       hostedZoneId: props.hostedZoneId,
     });
 
+    let cognitoWebAcl: WebAclForCognito | undefined;
+    if (props.allowedIpV4AddressRanges.length > 0 || props.allowedIpV6AddressRanges.length > 0) {
+      cognitoWebAcl = new WebAclForCognito(
+        this,
+        "WebAclForCognito",
+        {
+          envPrefix: props.envPrefix,
+          allowedIpV4AddressRanges: props.allowedIpV4AddressRanges,
+          allowedIpV6AddressRanges: props.allowedIpV6AddressRanges,
+        }
+      );
+    }
+
     const auth = new Auth(this, "Auth", {
       origin: frontend.getOrigin(),
       userPoolDomainPrefixKey: props.userPoolDomainPrefix,
@@ -153,6 +169,7 @@ export class BedrockChatStack extends cdk.Stack {
       autoJoinUserGroups: props.autoJoinUserGroups,
       selfSignUpEnabled: props.selfSignUpEnabled,
       tokenValidity: Duration.minutes(props.tokenValidMinutes),
+      webAclArn: cognitoWebAcl?.webAclArn,
     });
     const largeMessageBucket = new Bucket(this, "LargeMessageBucket", {
       encryption: BucketEncryption.S3_MANAGED,
@@ -213,7 +230,7 @@ export class BedrockChatStack extends cdk.Stack {
       ["aoss:DescribeCollectionItems"],
       ["aoss:DescribeIndex", "aoss:ReadDocument"]
     );
-    
+
     // Add data access policy for developers
     // Get IAM user/role ARN from environment variables
     if (props.devAccessIamRoleArn) {
@@ -224,13 +241,13 @@ export class BedrockChatStack extends cdk.Stack {
         iam.Role.fromRoleArn(this, "DevAccessIamRoleArn", props.devAccessIamRoleArn),
         [
           "aoss:DescribeCollectionItems",
-          "aoss:CreateCollectionItems", 
+          "aoss:CreateCollectionItems",
           "aoss:DeleteCollectionItems",
           "aoss:UpdateCollectionItems"
         ],
         [
-          "aoss:DescribeIndex", 
-          "aoss:ReadDocument", 
+          "aoss:DescribeIndex",
+          "aoss:ReadDocument",
           "aoss:WriteDocument",
           "aoss:CreateIndex",
           "aoss:DeleteIndex",

--- a/cdk/lib/constructs/webacl-for-cognito.ts
+++ b/cdk/lib/constructs/webacl-for-cognito.ts
@@ -1,0 +1,83 @@
+import { Construct } from "constructs";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import { CfnOutput } from "aws-cdk-lib";
+
+export interface WebAclForCognitoProps {
+  envPrefix: string;
+  readonly allowedIpV4AddressRanges: string[];
+  readonly allowedIpV6AddressRanges: string[];
+}
+
+export class WebAclForCognito extends Construct {
+  public readonly webAclArn: string;
+  constructor(scope: Construct, id: string, props: WebAclForCognitoProps) {
+    super(scope, id);
+
+    const sepHyphen = props.envPrefix ? "-" : "";
+    const rules: wafv2.CfnWebACL.RuleProperty[] = [];
+
+    if (props.allowedIpV4AddressRanges.length > 0) {
+      const ipV4SetReferenceStatement = new wafv2.CfnIPSet(this, "IpV4Set", {
+        ipAddressVersion: "IPV4",
+        scope: "REGIONAL",
+        addresses: props.allowedIpV4AddressRanges,
+      });
+      rules.push({
+        priority: 0,
+        name: "CognitoWebAclIpV4RuleSet",
+        action: { allow: {} },
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: "CognitoWebAcl",
+          sampledRequestsEnabled: true,
+        },
+        statement: {
+          ipSetReferenceStatement: { arn: ipV4SetReferenceStatement.attrArn },
+        },
+      });
+    }
+
+    if (props.allowedIpV6AddressRanges.length > 0) {
+      const ipV6SetReferenceStatement = new wafv2.CfnIPSet(this, "IpV6Set", {
+        ipAddressVersion: "IPV6",
+        scope: "REGIONAL",
+        addresses: props.allowedIpV6AddressRanges,
+      });
+      rules.push({
+        priority: 1,
+        name: "CognitoWebAclIpV6RuleSet",
+        action: { allow: {} },
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: "CognitoWebAcl",
+          sampledRequestsEnabled: true,
+        },
+        statement: {
+          ipSetReferenceStatement: { arn: ipV6SetReferenceStatement.attrArn },
+        },
+      });
+    }
+    if (rules.length > 0) {
+      const webAcl = new wafv2.CfnWebACL(this, "WebAcl", {
+        defaultAction: { block: {} },
+        name: `${props.envPrefix}${sepHyphen}CognitoWebAcl-${id}`,
+        scope: "REGIONAL",
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: "CognitoWebAcl",
+          sampledRequestsEnabled: true,
+        },
+        rules,
+      });
+      new CfnOutput(this, "WebAclArn", {
+        value: webAcl.attrArn,
+      });
+
+      this.webAclArn = webAcl.attrArn;
+    } else {
+      throw new Error(
+        "One or more allowed IP ranges for Cognito must be specified in IPv4 or IPv6."
+      );
+    }
+  }
+}

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -50,6 +50,8 @@ describe("Bedrock Chat Stack Test", () => {
         userPoolDomainPrefix: domainPrefix,
         publishedApiAllowedIpV4AddressRanges: [""],
         publishedApiAllowedIpV6AddressRanges: [""],
+        allowedIpV4AddressRanges: [""],
+        allowedIpV6AddressRanges: [""],
         allowedSignUpEmailDomains: [],
         autoJoinUserGroups: [],
         selfSignUpEnabled: true,
@@ -128,6 +130,8 @@ describe("Bedrock Chat Stack Test", () => {
         publishedApiAllowedIpV6AddressRanges: [""],
         allowedSignUpEmailDomains: [],
         autoJoinUserGroups: [],
+        allowedIpV4AddressRanges: [""],
+        allowedIpV6AddressRanges: [""],
         selfSignUpEnabled: true,
         enableIpV6: true,
         documentBucket: bedrockRegionResourcesStack.documentBucket,
@@ -196,6 +200,8 @@ describe("Bedrock Chat Stack Test", () => {
       autoJoinUserGroups: [],
       selfSignUpEnabled: true,
       enableIpV6: true,
+      allowedIpV4AddressRanges: [""],
+      allowedIpV6AddressRanges: [""],
       documentBucket: bedrockRegionResourcesStack.documentBucket,
       enableRagReplicas: false,
       enableBedrockCrossRegionInference: false,
@@ -244,6 +250,8 @@ describe("Bedrock Chat Stack Test", () => {
       documentBucket: bedrockRegionResourcesStack.documentBucket,
       enableRagReplicas: false,
       enableBedrockCrossRegionInference: false,
+      allowedIpV4AddressRanges: [""],
+      allowedIpV6AddressRanges: [""],
       enableLambdaSnapStart: true,
       alternateDomainName: "chat.example.com",
       hostedZoneId: "Z0123456789ABCDEF",
@@ -325,6 +333,8 @@ describe("Bedrock Chat Stack Test", () => {
       enableBedrockCrossRegionInference: false,
       enableLambdaSnapStart: true,
       alternateDomainName: "",
+      allowedIpV4AddressRanges: [""],
+      allowedIpV6AddressRanges: [""],
       hostedZoneId: "",
       enableBotStore: true,
       enableBotStoreReplicas: false,
@@ -384,6 +394,8 @@ describe("Bedrock Chat Stack Test", () => {
       enableBedrockCrossRegionInference: false,
       enableLambdaSnapStart: true,
       alternateDomainName: "chat.example.com",
+      allowedIpV4AddressRanges: [""],
+      allowedIpV6AddressRanges: [""],
       hostedZoneId: "Z0123456789ABCDEF",
       enableBotStore: true,
       enableBotStoreReplicas: false,
@@ -458,6 +470,8 @@ describe("Bedrock Chat Stack Test", () => {
       autoJoinUserGroups: [],
       selfSignUpEnabled: true,
       enableIpV6: true,
+      allowedIpV4AddressRanges: [""],
+      allowedIpV6AddressRanges: [""],
       documentBucket: bedrockRegionResourcesStack.documentBucket,
       enableRagReplicas: false,
       enableBedrockCrossRegionInference: false,
@@ -538,27 +552,27 @@ describe("Bedrock Knowledge Base Stack", () => {
             params.analyzer !== undefined
               ? JSON.parse(params.analyzer)
               : {
-                  character_filters: {
-                    L: [
-                      {
-                        S: "icu_normalizer",
-                      },
-                    ],
-                  },
-                  token_filters: {
-                    L: [
-                      {
-                        S: "kuromoji_baseform",
-                      },
-                      {
-                        S: "kuromoji_part_of_speech",
-                      },
-                    ],
-                  },
-                  tokenizer: {
-                    S: "kuromoji_tokenizer",
-                  },
+                character_filters: {
+                  L: [
+                    {
+                      S: "icu_normalizer",
+                    },
+                  ],
                 },
+                token_filters: {
+                  L: [
+                    {
+                      S: "kuromoji_baseform",
+                    },
+                    {
+                      S: "kuromoji_part_of_speech",
+                    },
+                  ],
+                },
+                tokenizer: {
+                  S: "kuromoji_tokenizer",
+                },
+              },
         },
       },
       embeddings_model: {


### PR DESCRIPTION
[Issue ](https://github.com/aws-samples/bedrock-chat/issues/776)#, if available:


Description of changes:
- Create WebAcl for cognito and attached it



- Ensure authenticated users cannot bypass IP restrictions by accessing backend APIs directly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.