### PR TITLE
feat: configure global available models

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,14 @@ Example usage:
     "selfSignUpEnabled": false,
     "enableLambdaSnapStart": true,
     "allowedIpV4AddressRanges": ["192.168.1.0/24"],
-    "allowedSignUpEmailDomains": ["example.com"]
+    "allowedSignUpEmailDomains": ["example.com"],
+    "globalAvailableModels": [
+      "claude-v3.7-sonnet",
+      "claude-v3.5-sonnet",
+      "amazon-nova-pro",
+      "amazon-nova-lite",
+      "llama3-3-70b-instruct"
+    ]
   }
 }'
 ```
@@ -135,6 +142,7 @@ The override JSON must follow the same structure as cdk.json. You can override a
 - `bedrockRegion`
 - `enableRagReplicas`
 - `enableBedrockCrossRegionInference`
+- `globalAvailableModels`: accepts a list of model IDs to enable. The default value is an empty list, which enables all models.
 - And other context values defined in cdk.json
 
 > [!Note]
@@ -203,11 +211,20 @@ cd cdk
 npm ci
 ```
 
-- If necessary, edit the following entries in [cdk.json](./cdk/cdk.json) if necessary.
+- If necessary, edit the following entries in [cdk.json](./cdk/cdk.json).
 
   - `bedrockRegion`: Region where Bedrock is available. **NOTE: Bedrock does NOT support all regions for now.**
   - `allowedIpV4AddressRanges`, `allowedIpV6AddressRanges`: Allowed IP Address range.
   - `enableLambdaSnapStart`: Defaults to true. Set to false if deploying to a [region that doesn't support Lambda SnapStart for Python functions](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-supported-regions).
+  - `globalAvailableModels`: Defaults to all. If set (list of model IDs), allows to globally control which models appear in dropdown menus across chats for all users and during bot creation in the Bedrock Chat application. 
+The following model IDs are supported (please make sure that they are also enabled in the Bedrock console under Model access in your deployment region):
+- **Claude Models:** `claude-v4-opus`, `claude-v4.1-opus`, `claude-v4-sonnet`, `claude-v3.5-sonnet`, `claude-v3.5-sonnet-v2`, `claude-v3.7-sonnet`, `claude-v3.5-haiku`, `claude-v3-haiku`, `claude-v3-opus`
+- **Amazon Nova Models:** `amazon-nova-pro`, `amazon-nova-lite`, `amazon-nova-micro`
+- **Mistral Models:** `mistral-7b-instruct`, `mixtral-8x7b-instruct`, `mistral-large`, `mistral-large-2`
+- **DeepSeek Models:** `deepseek-r1`
+- **Meta Llama Models:** `llama3-3-70b-instruct`, `llama3-2-1b-instruct`, `llama3-2-3b-instruct`, `llama3-2-11b-instruct`, `llama3-2-90b-instruct`
+
+The full list can be found in [index.ts](./frontend/src/constants/index.ts).
 
 - Before deploying the CDK, you will need to work with Bootstrap once for the region you are deploying to.
 
@@ -249,7 +266,14 @@ The traditional way to configure parameters is by editing the `cdk.json` file. T
   "context": {
     "bedrockRegion": "us-east-1",
     "allowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],
-    "selfSignUpEnabled": true
+    "selfSignUpEnabled": true,
+    "globalAvailableModels": [
+      "claude-v3.7-sonnet",
+      "claude-v3.5-sonnet",
+      "amazon-nova-pro",
+      "amazon-nova-lite",
+      "llama3-3-70b-instruct"
+    ],
   }
 }
 ```
@@ -264,6 +288,13 @@ bedrockChatParams.set("default", {
   bedrockRegion: "us-east-1",
   allowedIpV4AddressRanges: ["192.168.0.0/16"],
   selfSignUpEnabled: true,
+  globalAvailableModels: [
+      "claude-v3.7-sonnet",
+      "claude-v3.5-sonnet",
+      "amazon-nova-pro",
+      "amazon-nova-lite",
+      "llama3-3-70b-instruct"
+    ],
 });
 
 // Define parameters for additional environments

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import traceback
@@ -15,6 +14,7 @@ from app.routes.api_publication import router as api_publication_router
 from app.routes.bot import router as bot_router
 from app.routes.bot_store import router as bot_store_router
 from app.routes.conversation import router as conversation_router
+from app.routes.global_config import router as global_config_router
 from app.routes.published_api import router as published_api_router
 from app.routes.user import router as user_router
 from app.user import User
@@ -45,6 +45,7 @@ if not is_published_api:
         {"name": "admin", "description": "Admin API"},
         {"name": "user", "description": "User API (cognito)"},
         {"name": "bot_store", "description": "Bot Store API"},
+        {"name": "config", "description": "Model Configuration API"},
     ]
     title = "Bedrock Chat"
 else:
@@ -65,33 +66,9 @@ if not is_published_api:
     app.include_router(admin_router)
     app.include_router(user_router)
     app.include_router(bot_store_router)
+    app.include_router(global_config_router)
 else:
     app.include_router(published_api_router)
-
-
-def get_global_available_models() -> list[str] | None:
-    """
-    Get the list of globally available models from environment variable.
-    Returns None if not configured, which means all models are available.
-    """
-    global_models_env = os.environ.get("GLOBAL_AVAILABLE_MODELS")
-    if global_models_env:
-        try:
-            return json.loads(global_models_env)
-        except json.JSONDecodeError:
-            # If JSON parsing fails, treat as comma-separated list
-            return [
-                model.strip() for model in global_models_env.split(",") if model.strip()
-            ]
-    return None
-
-
-# Configuration endpoint
-@app.get("/config/global")
-def get_global_config():
-    """Get global configuration including available models."""
-    global_models = get_global_available_models()
-    return {"globalAvailableModels": global_models}
 
 
 app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,7 +45,7 @@ if not is_published_api:
         {"name": "admin", "description": "Admin API"},
         {"name": "user", "description": "User API (cognito)"},
         {"name": "bot_store", "description": "Bot Store API"},
-        {"name": "config", "description": "Model Configuration API"},
+        {"name": "config", "description": "Global Configuration API"},
     ]
     title = "Bedrock Chat"
 else:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,7 +83,7 @@ def get_global_available_models() -> list[str] | None:
             return [model.strip() for model in global_models_env.split(",") if model.strip()]
     return None
 
-# Configuration endpoint (available for all deployments)
+# Configuration endpoint
 @app.get("/config/global")
 def get_global_config():
     """Get global configuration including available models."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -80,17 +80,18 @@ def get_global_available_models() -> list[str] | None:
             return json.loads(global_models_env)
         except json.JSONDecodeError:
             # If JSON parsing fails, treat as comma-separated list
-            return [model.strip() for model in global_models_env.split(",") if model.strip()]
+            return [
+                model.strip() for model in global_models_env.split(",") if model.strip()
+            ]
     return None
+
 
 # Configuration endpoint
 @app.get("/config/global")
 def get_global_config():
     """Get global configuration including available models."""
     global_models = get_global_available_models()
-    return {
-        "globalAvailableModels": global_models
-    }
+    return {"globalAvailableModels": global_models}
 
 
 app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import traceback
@@ -26,6 +27,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp, Message
+
 
 CORS_ALLOW_ORIGINS = os.environ.get("CORS_ALLOW_ORIGINS", "*")
 PUBLISHED_API_ID = os.environ.get("PUBLISHED_API_ID", None)
@@ -65,6 +67,30 @@ if not is_published_api:
     app.include_router(bot_store_router)
 else:
     app.include_router(published_api_router)
+
+
+def get_global_available_models() -> list[str] | None:
+    """
+    Get the list of globally available models from environment variable.
+    Returns None if not configured, which means all models are available.
+    """
+    global_models_env = os.environ.get("GLOBAL_AVAILABLE_MODELS")
+    if global_models_env:
+        try:
+            return json.loads(global_models_env)
+        except json.JSONDecodeError:
+            # If JSON parsing fails, treat as comma-separated list
+            return [model.strip() for model in global_models_env.split(",") if model.strip()]
+    return None
+
+# Configuration endpoint (available for all deployments)
+@app.get("/config/global")
+def get_global_config():
+    """Get global configuration including available models."""
+    global_models = get_global_available_models()
+    return {
+        "globalAvailableModels": global_models
+    }
 
 
 app.add_middleware(

--- a/backend/app/routes/global_config.py
+++ b/backend/app/routes/global_config.py
@@ -1,0 +1,37 @@
+import json
+import logging
+import os
+
+from fastapi import APIRouter
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GLOBAL_AVAILABLE_MODELS = os.environ.get("GLOBAL_AVAILABLE_MODELS")
+router = APIRouter(tags=["config"])
+
+
+def get_global_available_models() -> list[str] | None:
+    """
+    Get the list of globally available models from environment variable.
+    Returns None if not configured, which means all models are available.
+    """
+    if GLOBAL_AVAILABLE_MODELS:
+        try:
+            models = json.loads(GLOBAL_AVAILABLE_MODELS)
+            logger.info(f"Global available models (JSON): {models}")
+            return models
+        except json.JSONDecodeError:
+            # If JSON parsing fails, return error
+            logger.error("Failed to parse GLOBAL_AVAILABLE_MODELS as JSON")
+            return None
+        
+    logger.info("No global available models configured - all models are available")
+    return None
+
+
+@router.get("/config/global")
+def get_global_config():
+    """Get global configuration including available models."""
+    global_models = get_global_available_models()
+    return {"globalAvailableModels": global_models}

--- a/backend/app/routes/global_config.py
+++ b/backend/app/routes/global_config.py
@@ -1,33 +1,8 @@
-import json
-import logging
-import os
-
 from fastapi import APIRouter
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s - %(message)s")
-logger = logging.getLogger(__name__)
+from app.usecases.global_config import get_global_available_models
 
-GLOBAL_AVAILABLE_MODELS = os.environ.get("GLOBAL_AVAILABLE_MODELS")
 router = APIRouter(tags=["config"])
-
-
-def get_global_available_models() -> list[str] | None:
-    """
-    Get the list of globally available models from environment variable.
-    Returns None if not configured, which means all models are available.
-    """
-    if GLOBAL_AVAILABLE_MODELS:
-        try:
-            models = json.loads(GLOBAL_AVAILABLE_MODELS)
-            logger.info(f"Global available models (JSON): {models}")
-            return models
-        except json.JSONDecodeError:
-            # If JSON parsing fails, return error
-            logger.error("Failed to parse GLOBAL_AVAILABLE_MODELS as JSON")
-            return None
-
-    logger.info("No global available models configured - all models are available")
-    return None
 
 
 @router.get("/config/global")

--- a/backend/app/routes/global_config.py
+++ b/backend/app/routes/global_config.py
@@ -25,7 +25,7 @@ def get_global_available_models() -> list[str] | None:
             # If JSON parsing fails, return error
             logger.error("Failed to parse GLOBAL_AVAILABLE_MODELS as JSON")
             return None
-        
+
     logger.info("No global available models configured - all models are available")
     return None
 

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -1,0 +1,34 @@
+import json
+import logging
+import os
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+GLOBAL_AVAILABLE_MODELS = os.environ.get("GLOBAL_AVAILABLE_MODELS")
+
+
+def get_global_available_models() -> list[str]:
+    """
+    Get the list of globally available models from environment variable.
+    Returns empty list if not configured or if an empty array is provided,
+    which means all models are available.
+    """
+    if GLOBAL_AVAILABLE_MODELS:
+        try:
+            models = json.loads(GLOBAL_AVAILABLE_MODELS)
+            logger.info(f"Global available models (JSON): {models}")
+            # Ensure the result is a list
+            if isinstance(models, list):
+                return models
+            else:
+                logger.error(
+                    f"GLOBAL_AVAILABLE_MODELS must be a JSON array, got {type(models)}"
+                )
+                return []
+        except json.JSONDecodeError:
+            logger.error("Failed to parse GLOBAL_AVAILABLE_MODELS as JSON")
+            return []
+
+    logger.info("No global available models configured - all models are available")
+    return []

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -17,9 +17,9 @@ def get_global_available_models() -> list[str]:
     if GLOBAL_AVAILABLE_MODELS:
         try:
             models = json.loads(GLOBAL_AVAILABLE_MODELS)
-            logger.info(f"Global available models (JSON): {models}")
             # Ensure the result is a list
             if isinstance(models, list):
+                logger.info(f"Global available models (JSON): {models}")
                 # Filter out empty strings and None values
                 filtered_models = [
                     model for model in models if model and isinstance(model, str)

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -20,7 +20,11 @@ def get_global_available_models() -> list[str]:
             logger.info(f"Global available models (JSON): {models}")
             # Ensure the result is a list
             if isinstance(models, list):
-                return models
+                # Filter out empty strings and None values
+                filtered_models = [
+                    model for model in models if model and isinstance(model, str)
+                ]
+                return filtered_models
             else:
                 logger.error(
                     f"GLOBAL_AVAILABLE_MODELS must be a JSON array, got {type(models)}"

--- a/backend/tests/test_usecases/test_global_config.py
+++ b/backend/tests/test_usecases/test_global_config.py
@@ -1,0 +1,126 @@
+import sys
+
+sys.path.insert(0, ".")
+import unittest
+from unittest.mock import patch
+
+from app.usecases import global_config
+from app.usecases.global_config import get_global_available_models
+
+
+class TestGetGlobalAvailableModels(unittest.TestCase):
+    """Test cases for get_global_available_models function."""
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", None)
+    def test_no_environment_variable_returns_empty_list(self):
+        """Test that when no GLOBAL_AVAILABLE_MODELS env var is set, empty list is returned."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", "")
+    def test_empty_environment_variable_returns_empty_list(self):
+        """Test that when GLOBAL_AVAILABLE_MODELS is empty string, empty list is returned."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", "[]")
+    def test_empty_json_array_returns_empty_list(self):
+        """Test that empty JSON array returns empty list."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(
+        global_config,
+        "GLOBAL_AVAILABLE_MODELS",
+        '["claude-v3.7-sonnet", "claude-v3.5-sonnet", "amazon-nova-pro"]',
+    )
+    def test_valid_json_array_returns_models(self):
+        """Test that valid JSON array returns the list of models."""
+        result = get_global_available_models()
+        self.assertEqual(
+            result, ["claude-v3.7-sonnet", "claude-v3.5-sonnet", "amazon-nova-pro"]
+        )
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", "invalid json")
+    def test_invalid_json_returns_empty_list(self):
+        """Test that invalid JSON returns empty list."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '{"not": "an array"}')
+    def test_json_object_instead_of_array_returns_empty_list(self):
+        """Test that JSON object (not array) returns empty list."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '"string instead of array"')
+    def test_json_string_instead_of_array_returns_empty_list(self):
+        """Test that JSON string (not array) returns empty list."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", "true")
+    def test_json_boolean_instead_of_array_returns_empty_list(self):
+        """Test that JSON boolean (not array) returns empty list."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '[""]')
+    def test_empty_string_models_filtered_out(self):
+        """Test that empty string models are filtered out from the array."""
+        result = get_global_available_models()
+        self.assertEqual(result, [])
+
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '[null, "valid-model"]')
+    def test_null_values_filtered_out(self):
+        """Test that null values are filtered out from the array."""
+        result = get_global_available_models()
+        self.assertEqual(result, ["valid-model"])
+
+    @patch.object(
+        global_config, "GLOBAL_AVAILABLE_MODELS", '["model1", "", null, "model2", ""]'
+    )
+    def test_mixed_valid_and_invalid_values_filtered(self):
+        """Test that empty strings and null values are filtered out, keeping only valid models."""
+        result = get_global_available_models()
+        self.assertEqual(result, ["model1", "model2"])
+
+    @patch("app.usecases.global_config.logger")
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '["test-model"]')
+    def test_logging_for_valid_models(self, mock_logger):
+        """Test that appropriate log message is generated for valid models."""
+        result = get_global_available_models()
+        mock_logger.info.assert_called_with(
+            "Global available models (JSON): ['test-model']"
+        )
+        self.assertEqual(result, ["test-model"])
+
+    @patch("app.usecases.global_config.logger")
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", None)
+    def test_logging_for_no_config(self, mock_logger):
+        """Test that appropriate log message is generated when no config is set."""
+        result = get_global_available_models()
+        mock_logger.info.assert_called_with(
+            "No global available models configured - all models are available"
+        )
+        self.assertEqual(result, [])
+
+    @patch("app.usecases.global_config.logger")
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", "invalid json")
+    def test_logging_for_invalid_json(self, mock_logger):
+        """Test that error is logged for invalid JSON."""
+        result = get_global_available_models()
+        mock_logger.error.assert_called_with(
+            "Failed to parse GLOBAL_AVAILABLE_MODELS as JSON"
+        )
+        self.assertEqual(result, [])
+
+    @patch("app.usecases.global_config.logger")
+    @patch.object(global_config, "GLOBAL_AVAILABLE_MODELS", '{"not": "array"}')
+    def test_logging_for_non_array_type(self, mock_logger):
+        """Test that error is logged for non-array JSON types."""
+        result = get_global_available_models()
+        mock_logger.error.assert_called_with(
+            "GLOBAL_AVAILABLE_MODELS must be a JSON array, got <class 'dict'>"
+        )
+        self.assertEqual(result, [])

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -93,6 +93,7 @@ const chat = new BedrockChatStack(
     enableBotStore: params.enableBotStore,
     enableBotStoreReplicas: params.enableBotStoreReplicas,
     botStoreLanguage: params.botStoreLanguage,
+    globalAvailableModels: params.globalAvailableModels,
     tokenValidMinutes: params.tokenValidMinutes,
     devAccessIamRoleArn: params.devAccessIamRoleArn,
   }

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -73,6 +73,7 @@
     "enableBotStore": true,
     "enableBotStoreReplicas": false,
     "botStoreLanguage": "en",
+    "globalAvailableModels": [],
     "tokenValidMinutes": 30,
     "alternateDomainName": "",
     "hostedZoneId": "",

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -47,6 +47,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly enableBotStore: boolean;
   readonly enableBotStoreReplicas: boolean;
   readonly botStoreLanguage: Language;
+  readonly globalAvailableModels?: string[];
   readonly tokenValidMinutes: number;
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;
@@ -203,6 +204,7 @@ export class BedrockChatStack extends cdk.Stack {
         props.enableBedrockCrossRegionInference,
       enableLambdaSnapStart: props.enableLambdaSnapStart,
       openSearchEndpoint: botStore?.openSearchEndpoint,
+      globalAvailableModels: props.globalAvailableModels,
     });
     props.documentBucket.grantReadWrite(backendApi.handler);
     // Add permissions to API handler for BotStore

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -47,7 +47,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly enableBotStore: boolean;
   readonly enableBotStoreReplicas: boolean;
   readonly botStoreLanguage: Language;
-  readonly globalAvailableModels: string[];
+  readonly globalAvailableModels?: string[];
   readonly tokenValidMinutes: number;
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -47,7 +47,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly enableBotStore: boolean;
   readonly enableBotStoreReplicas: boolean;
   readonly botStoreLanguage: Language;
-  readonly globalAvailableModels?: string[];
+  readonly globalAvailableModels: string[];
   readonly tokenValidMinutes: number;
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -42,7 +42,7 @@ export interface ApiProps {
   readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
   readonly openSearchEndpoint?: string;
-  readonly globalAvailableModels?: string[];
+  readonly globalAvailableModels: string[];
 }
 
 export class Api extends Construct {
@@ -266,7 +266,7 @@ export class Api extends Construct {
           props.enableBedrockCrossRegionInference.toString(),
         GLOBAL_AVAILABLE_MODELS: props.globalAvailableModels 
           ? JSON.stringify(props.globalAvailableModels)
-          : "",
+          : "[]",
         OPENSEARCH_DOMAIN_ENDPOINT: props.openSearchEndpoint || "",
         AWS_LAMBDA_EXEC_WRAPPER: "/opt/bootstrap",
         PORT: "8000",

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -42,6 +42,7 @@ export interface ApiProps {
   readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
   readonly openSearchEndpoint?: string;
+  readonly globalAvailableModels?: string[];
 }
 
 export class Api extends Construct {
@@ -263,6 +264,9 @@ export class Api extends Construct {
         USAGE_ANALYSIS_OUTPUT_LOCATION: usageAnalysisOutputLocation,
         ENABLE_BEDROCK_CROSS_REGION_INFERENCE:
           props.enableBedrockCrossRegionInference.toString(),
+        GLOBAL_AVAILABLE_MODELS: props.globalAvailableModels 
+          ? JSON.stringify(props.globalAvailableModels)
+          : "",
         OPENSEARCH_DOMAIN_ENDPOINT: props.openSearchEndpoint || "",
         AWS_LAMBDA_EXEC_WRAPPER: "/opt/bootstrap",
         PORT: "8000",

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -42,7 +42,7 @@ export interface ApiProps {
   readonly enableBedrockCrossRegionInference: boolean;
   readonly enableLambdaSnapStart: boolean;
   readonly openSearchEndpoint?: string;
-  readonly globalAvailableModels: string[];
+  readonly globalAvailableModels?: string[];
 }
 
 export class Api extends Construct {

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -100,6 +100,9 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   // ID token refresh interval
   tokenValidMinutes: z.number().default(30),
 
+  // Global model configuration
+  globalAvailableModels: z.array(z.string()).optional(),
+
   // debug parameter
   devAccessIamRoleArn: z.string().default("")
 });
@@ -224,6 +227,7 @@ export function resolveBedrockChatParameters(
     enableBotStore: app.node.tryGetContext("enableBotStore"),
     enableBotStoreReplicas: app.node.tryGetContext("EnableBotStoreReplicas"),
     botStoreLanguage: app.node.tryGetContext("botStoreLanguage"),
+    globalAvailableModels: app.node.tryGetContext("globalAvailableModels"),
     devAccessIamRoleArn: app.node.tryGetContext("devAccessIamRoleArn"),
   };
 

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -101,7 +101,7 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   tokenValidMinutes: z.number().default(30),
 
   // Global model configuration
-  globalAvailableModels: z.array(z.string()).optional(),
+  globalAvailableModels: z.array(z.string()).default([]),
 
   // debug parameter
   devAccessIamRoleArn: z.string().default("")

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -101,6 +101,7 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   tokenValidMinutes: z.number().default(30),
 
   // Global model configuration
+  // If not configured (empty array), all models are available
   globalAvailableModels: z.array(z.string()).default([]),
 
   // debug parameter

--- a/frontend/src/@types/global-config.d.ts
+++ b/frontend/src/@types/global-config.d.ts
@@ -1,0 +1,16 @@
+import { AVAILABLE_MODEL_KEYS } from '../constants/index';
+
+export interface GlobalConfig {
+  globalAvailableModels: string[];
+}
+
+export interface GetGlobalConfigResponse extends GlobalConfig {}
+
+export interface ModelItem {
+  modelId: (typeof AVAILABLE_MODEL_KEYS)[number];
+  label: string;
+  supportMediaType: string[];
+  supportReasoning: boolean;
+  forceReasoningEnabled?: boolean;
+  description?: string;
+}

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -68,6 +68,7 @@ import {
   WebCrawlingScope,
 } from '../types';
 import { toCamelCase } from '../../../utils/StringUtils';
+import useGlobalConfig from '../../../hooks/useGlobalConfig';
 
 const edgeGenerationParams = EDGE_GENERATION_PARAMS;
 
@@ -79,6 +80,8 @@ const BotKbEditPage: React.FC = () => {
   const { botId: paramsBotId } = useParams();
   const { getMyBot, registerBot, updateBot } = useBot();
   const { availableTools } = useAgent();
+  const { getGlobalConfig } = useGlobalConfig();
+  const { data: globalConfig } = getGlobalConfig();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -172,7 +175,16 @@ const BotKbEditPage: React.FC = () => {
     description: string;
   }[] = (() => {
     const getGeneralModels = () => {
-      return AVAILABLE_MODEL_KEYS.map((key) => ({
+      let availableKeys = [...AVAILABLE_MODEL_KEYS];
+      
+      // Filter by global configuration if available
+      if (globalConfig?.globalAvailableModels && globalConfig.globalAvailableModels.length > 0) {
+        availableKeys = availableKeys.filter(key => 
+          globalConfig.globalAvailableModels!.includes(key)
+        );
+      }
+      
+      return availableKeys.map((key) => ({
         key: key as Model,
         label: t(`model.${key}.label`) as string,
         description: t(`model.${key}.description`) as string,

--- a/frontend/src/hooks/useGlobalConfig.ts
+++ b/frontend/src/hooks/useGlobalConfig.ts
@@ -1,0 +1,17 @@
+import useHttp from './useHttp';
+
+interface GlobalConfig {
+  globalAvailableModels?: string[] | null;
+}
+
+const useGlobalConfig = () => {
+  const http = useHttp();
+
+  return {
+    getGlobalConfig: () => {
+      return http.get<GlobalConfig>('config/global');
+    },
+  };
+};
+
+export default useGlobalConfig;

--- a/frontend/src/hooks/useGlobalConfig.ts
+++ b/frontend/src/hooks/useGlobalConfig.ts
@@ -1,16 +1,10 @@
-import useHttp from './useHttp';
-
-interface GlobalConfig {
-  globalAvailableModels?: string[] | null;
-}
+import useGlobalConfigApi from './useGlobalConfigApi';
 
 const useGlobalConfig = () => {
-  const http = useHttp();
+  const api = useGlobalConfigApi();
 
   return {
-    getGlobalConfig: () => {
-      return http.get<GlobalConfig>('config/global');
-    },
+    getGlobalConfig: api.getGlobalConfig,
   };
 };
 

--- a/frontend/src/hooks/useGlobalConfigApi.ts
+++ b/frontend/src/hooks/useGlobalConfigApi.ts
@@ -1,0 +1,14 @@
+import { GetGlobalConfigResponse } from '../@types/global-config';
+import useHttp from './useHttp';
+
+const useGlobalConfigApi = () => {
+  const http = useHttp();
+
+  return {
+    getGlobalConfig: () => {
+      return http.get<GetGlobalConfigResponse>('config/global');
+    },
+  };
+};
+
+export default useGlobalConfigApi;

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -4,6 +4,7 @@ import { AVAILABLE_MODEL_KEYS } from '../constants/index';
 import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useLocalStorage from './useLocalStorage';
+import useGlobalConfig from './useGlobalConfig';
 import { ActiveModels } from '../@types/bot';
 import { toCamelCase } from '../utils/StringUtils';
 
@@ -54,6 +55,9 @@ const usePreviousBotId = (botId: string | null | undefined) => {
 };
 
 const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
+  const { getGlobalConfig } = useGlobalConfig();
+  const { data: globalConfig } = getGlobalConfig();
+
   const processedActiveModels = useMemo(() => {
     // Early return if activeModels is provided and not empty
     if (activeModels && Object.keys(activeModels).length > 0) {
@@ -71,16 +75,16 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   const { t } = useTranslation();
   const previousBotId = usePreviousBotId(botId);
 
-  const availableModels = useMemo<
-    {
-      modelId: Model;
-      label: string;
-      supportMediaType: string[];
-      supportReasoning: boolean;
-      forceReasoningEnabled?: boolean;
-      description?: string;
-    }[]
-  >(() => {
+  type ModelItem = {
+    modelId: (typeof AVAILABLE_MODEL_KEYS)[number];
+    label: string;
+    supportMediaType: string[];
+    supportReasoning: boolean;
+    forceReasoningEnabled?: boolean;
+    description?: string;
+  };
+  
+  const availableModels = useMemo<ModelItem[]>(() => {
     return [
       {
         modelId: 'claude-v4-opus',
@@ -241,8 +245,15 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportMediaType: [],
         supportReasoning: false,
       },
-    ];
-  }, [t]);
+    ].filter((model) => {
+      // Filter based on global configuration if available
+      if (globalConfig?.globalAvailableModels && globalConfig.globalAvailableModels.length > 0) {
+        return globalConfig.globalAvailableModels.includes(model.modelId);
+      }
+      // If no global config, show all models
+      return true;
+    }) as ModelItem[];
+  }, [t, globalConfig]);
 
   const [filteredModels, setFilteredModels] = useState(availableModels);
   const { modelId, setModelId } = useModelState();
@@ -260,7 +271,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   // Update filtered models when activeModels changes
   useEffect(() => {
     if (processedActiveModels) {
-      const filtered = availableModels.filter((model) => {
+      const filtered = availableModels.filter((model: ModelItem) => {
         const key = toCamelCase(model.modelId) as keyof ActiveModels;
         return processedActiveModels[key] !== false;
       });
@@ -271,7 +282,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   const getDefaultModel = useCallback(() => {
     // check default model is available
     const defaultModelAvailable = filteredModels.some(
-      (m) => m.modelId === DEFAULT_MODEL
+      (m: ModelItem) => m.modelId === DEFAULT_MODEL
     );
     if (defaultModelAvailable) {
       return DEFAULT_MODEL;
@@ -284,7 +295,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   const selectModel = useCallback(
     (targetModelId: Model) => {
       const modelExists = filteredModels.some(
-        (m) => toCamelCase(m.modelId) === toCamelCase(targetModelId)
+        (m: ModelItem) => toCamelCase(m.modelId) === toCamelCase(targetModelId)
       );
       return modelExists ? targetModelId : getDefaultModel();
     },
@@ -314,7 +325,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
       } else {
         // If there is no bot-specific model ID, check if the last model used can be used
         const lastModelAvailable = filteredModels.some(
-          (m) => m.modelId === recentUseModelId
+          (m: ModelItem) => m.modelId === recentUseModelId
         );
 
         // If the last model used is available, use it.
@@ -330,7 +341,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
       // Processing when botId and previousBotID are the same, but there is an update in FilteredModels
       if (botId) {
         const lastModelAvailable = filteredModels.some(
-          (m) =>
+          (m: ModelItem) =>
             toCamelCase(m.modelId) === toCamelCase(recentUseModelId) ||
             toCamelCase(m.modelId) === toCamelCase(botModelId)
         );
@@ -346,7 +357,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
 
   const model = useMemo(() => {
     return filteredModels.find(
-      (model) => toCamelCase(model.modelId) === toCamelCase(modelId)
+      (model: ModelItem) => toCamelCase(model.modelId) === toCamelCase(modelId)
     );
   }, [filteredModels, modelId]);
 
@@ -362,7 +373,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
     model,
     disabledImageUpload: (model?.supportMediaType.length ?? 0) === 0,
     acceptMediaType:
-      model?.supportMediaType.flatMap((mediaType) => {
+      model?.supportMediaType.flatMap((mediaType: string) => {
         const ext = mediaType.split('/')[1];
         return ext === 'jpeg' ? ['.jpg', '.jpeg'] : [`.${ext}`];
       }) ?? [],

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { Model } from '../@types/conversation';
+import { ModelItem } from '../@types/global-config';
 import { AVAILABLE_MODEL_KEYS } from '../constants/index';
 import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -75,15 +76,6 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   const { t } = useTranslation();
   const previousBotId = usePreviousBotId(botId);
 
-  type ModelItem = {
-    modelId: (typeof AVAILABLE_MODEL_KEYS)[number];
-    label: string;
-    supportMediaType: string[];
-    supportReasoning: boolean;
-    forceReasoningEnabled?: boolean;
-    description?: string;
-  };
-  
   const availableModels = useMemo<ModelItem[]>(() => {
     return [
       {

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -239,7 +239,10 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
       },
     ].filter((model) => {
       // Filter based on global configuration if available
-      if (globalConfig?.globalAvailableModels && globalConfig.globalAvailableModels.length > 0) {
+      if (
+        globalConfig?.globalAvailableModels &&
+        globalConfig.globalAvailableModels.length > 0
+      ) {
         return globalConfig.globalAvailableModels.includes(model.modelId);
       }
       // If no global config, show all models


### PR DESCRIPTION
*Issue #, if available:* #835

*Description of changes:*

- Added CDK configuration parameter `globalAvailableModels` in cdk.json to allow administrators to control which LLM models are available globally across all chat sessions
- Created backend API endpoint global_config in app/routes to expose global model settings to the frontend via environment variable GLOBAL_AVAILABLE_MODELS
- Implemented frontend hook `useGlobalConfigApi.ts` to fetch global configuration from the backend API and integrate it into the React application state management
- Enhanced useModel hook with global model filtering logic that applies before bot-specific filtering, ensuring only globally-allowed models appear in chat session dropdowns while maintaining backwards compatibility
- Updated bot creation/editing page BotKbEditPage.tsx to respect global model configuration, preventing users from enabling models that are globally disabled during bot setup
- Added type safety with `ModelItem` type definitions and proper type annotations throughout the model filtering code to prevent runtime errors
- Maintained backwards compatibility by defaulting to show all models when no global configuration is set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
