### PR TITLE
Add a new configuration variable `allowedCountries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Example usage:
     "selfSignUpEnabled": false,
     "enableLambdaSnapStart": true,
     "allowedIpV4AddressRanges": ["192.168.1.0/24"],
+    "allowedCountries": ["US", "CA"],
     "allowedSignUpEmailDomains": ["example.com"]
   }
 }'
@@ -131,6 +132,7 @@ The override JSON must follow the same structure as cdk.json. You can override a
 - `enableLambdaSnapStart`
 - `allowedIpV4AddressRanges`
 - `allowedIpV6AddressRanges`
+- `allowedCountries`
 - `allowedSignUpEmailDomains`
 - `bedrockRegion`
 - `enableRagReplicas`

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -95,6 +95,7 @@ const chat = new BedrockChatStack(
     botStoreLanguage: params.botStoreLanguage,
     tokenValidMinutes: params.tokenValidMinutes,
     devAccessIamRoleArn: params.devAccessIamRoleArn,
+    allowedCountries: params.allowedCountries,
   }
 );
 chat.addDependency(waf);

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -57,6 +57,7 @@
       "0000:0000:0000:0000:0000:0000:0000:0000/1",
       "8000:0000:0000:0000:0000:0000:0000:0000/1"
     ],
+    "allowedCountries": [],
     "identityProviders": [],
     "userPoolDomainPrefix": "",
     "allowedSignUpEmailDomains": [],

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -51,6 +51,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;
   readonly devAccessIamRoleArn?: string;
+  readonly allowedCountries?: string[];
 }
 
 export class BedrockChatStack extends cdk.Stack {
@@ -143,6 +144,7 @@ export class BedrockChatStack extends cdk.Stack {
       enableIpV6: props.enableIpV6,
       alternateDomainName: props.alternateDomainName,
       hostedZoneId: props.hostedZoneId,
+      allowedCountries: props.allowedCountries,
     });
 
     const auth = new Auth(this, "Auth", {

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -71,6 +71,9 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
       "8000:0000:0000:0000:0000:0000:0000:0000/1",
     ]),
 
+  // Optional list of allowed countries specified as ISO 3166-1 alpha-2 codes
+  allowedCountries: z.array(z.string()).default([]),
+
   // Authentication and user management
   identityProviders: z
     .unknown()
@@ -201,6 +204,7 @@ export function resolveBedrockChatParameters(
     allowedIpV6AddressRanges: app.node.tryGetContext(
       "allowedIpV6AddressRanges"
     ),
+    allowedCountries: app.node.tryGetContext("allowedCountries"),
     identityProviders: app.node.tryGetContext("identityProviders"),
     userPoolDomainPrefix: app.node.tryGetContext("userPoolDomainPrefix"),
     allowedSignUpEmailDomains: app.node.tryGetContext(

--- a/cdk/test/utils/parameter-models.test.ts
+++ b/cdk/test/utils/parameter-models.test.ts
@@ -295,6 +295,46 @@ describe("resolveBedrockChatParameters", () => {
       ]);
       // Note: Actual validation is performed in identityProvider function
     });
+
+    // Tests for allowedCountries parameter
+    test("should default allowedCountries to empty array", () => {
+      // Given
+      const app = createTestApp();
+
+      // When
+      const result = resolveBedrockChatParameters(app);
+
+      // Then
+      expect(result.allowedCountries).toEqual([]);
+    });
+
+    test("should parse allowedCountries from CDK context", () => {
+      // Given
+      const app = createTestApp({
+        allowedCountries: ["NZ", "AU"],
+      });
+
+      // When
+      const result = resolveBedrockChatParameters(app);
+
+      // Then
+      expect(result.allowedCountries).toEqual(["NZ", "AU"]);
+    });
+
+    test("should parse allowedCountries from parametersInput", () => {
+      // Given
+      const app = createTestApp();
+      const inputParams = {
+        bedrockRegion: "eu-west-1",
+        allowedCountries: ["US", "GB"],
+      };
+
+      // When
+      const result = resolveBedrockChatParameters(app, inputParams);
+
+      // Then
+      expect(result.allowedCountries).toEqual(["US", "GB"]);
+    });
   });
 
   test("should correctly parse parameters mimicking cdk.json context properties", () => {


### PR DESCRIPTION
Add a new configuration variable `allowedCountries` that is used for geolocation restriction in CloudFront. 

For example, setting `"allowedCountries": ["US", "CA"]` permits access only from US and Canada based IPs and not from anywhere else.

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
