### PR TITLE
Add GPT-OSS

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -659,6 +659,9 @@ def get_model_id(
         "llama3-2-3b-instruct": "meta.llama3-2-3b-instruct-v1:0",
         "llama3-2-11b-instruct": "meta.llama3-2-11b-instruct-v1:0",
         "llama3-2-90b-instruct": "meta.llama3-2-90b-instruct-v1:0",
+        # OpenAI GPT-OSS models
+        "gpt-oss-20b": "openai.gpt-oss-20b-1:0",
+        "gpt-oss-120b": "openai.gpt-oss-120b-1:0",
     }
 
     # Made this list by scripts/cross_region_inference/get_supported_cross_region_inferences.py
@@ -730,6 +733,8 @@ def get_model_id(
                 "llama3-2-3b-instruct",
                 "llama3-2-11b-instruct",
                 "llama3-2-90b-instruct",
+                "gpt-oss-20b",
+                "gpt-oss-120b",
             ],
         },
         "eu-central-1": {

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -242,12 +242,8 @@ REGIONAL_INFERENCE_PROFILES = {
         "supported_regions": {"us-east-1": "us", "us-east-2": "us", "us-west-2": "us"}
     },
     # OpenAI GPT-OSS models
-    "gpt-oss-20b": {
-        "supported_regions": {"us-west-2": "us"}
-    },
-    "gpt-oss-120b": {
-        "supported_regions": {"us-west-2": "us"}
-    },
+    "gpt-oss-20b": {"supported_regions": {"us-west-2": "us"}},
+    "gpt-oss-120b": {"supported_regions": {"us-west-2": "us"}},
 }
 
 client = get_bedrock_runtime_client()

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -241,9 +241,6 @@ REGIONAL_INFERENCE_PROFILES = {
     "llama3-2-90b-instruct": {
         "supported_regions": {"us-east-1": "us", "us-east-2": "us", "us-west-2": "us"}
     },
-    # OpenAI GPT-OSS models
-    "gpt-oss-20b": {"supported_regions": {"us-west-2": "us"}},
-    "gpt-oss-120b": {"supported_regions": {"us-west-2": "us"}},
 }
 
 client = get_bedrock_runtime_client()
@@ -274,6 +271,11 @@ def is_llama_model(model: type_model_name) -> bool:
 def is_mistral(model: type_model_name) -> bool:
     """Check if the model is a Mistral model"""
     return "mistral" in model
+
+
+def is_gpt_oss_model(model: type_model_name) -> bool:
+    """Check if the model is an OpenAI GPT-OSS model"""
+    return "gpt-oss" in model
 
 
 def is_tooluse_supported(model: type_model_name) -> bool:
@@ -398,6 +400,40 @@ def _prepare_mistral_model_params(
     return inference_config, additional_fields
 
 
+def _prepare_gpt_oss_model_params(
+    model: type_model_name, generation_params: Optional[GenerationParamsModel] = None
+) -> Tuple[InferenceConfigurationTypeDef, Dict[str, int] | None]:
+    """
+    Prepare inference configuration for OpenAI GPT-OSS models
+    Note: GPT-OSS models don't support stopSequences
+    """
+    # Base inference configuration
+    inference_config: InferenceConfigurationTypeDef = {
+        "maxTokens": (
+            generation_params.max_tokens
+            if generation_params
+            else DEFAULT_GENERATION_CONFIG["max_tokens"]
+        ),
+        "temperature": (
+            generation_params.temperature
+            if generation_params
+            else DEFAULT_GENERATION_CONFIG["temperature"]
+        ),
+        "topP": (
+            generation_params.top_p
+            if generation_params
+            else DEFAULT_GENERATION_CONFIG["top_p"]
+        ),
+    }
+
+    # Note: GPT-OSS models don't support stopSequences, so we don't add it
+
+    # Additional fields for GPT-OSS models
+    additional_fields = None
+
+    return inference_config, additional_fields
+
+
 def _prepare_llama_model_params(
     model: type_model_name, generation_params: Optional[GenerationParamsModel] = None
 ) -> Tuple[InferenceConfigurationTypeDef, None]:
@@ -498,9 +534,9 @@ def compose_args_for_converse_api(
     prompt_caching_enabled: bool = False,
 ) -> ConverseStreamRequestTypeDef:
     def process_content(c: ContentModel, role: str) -> list[ContentBlockTypeDef]:
-        # Drop unsigned reasoning blocks only for DeepSeek R1
+        # Drop unsigned reasoning blocks for DeepSeek R1 and GPT-OSS models
         if (
-            is_deepseek_model(model)
+            (is_deepseek_model(model) or is_gpt_oss_model(model))
             and c.content_type == "reasoning"
             and not getattr(c, "signature", None)
         ):
@@ -601,6 +637,21 @@ def compose_args_for_converse_api(
         # Special handling for Mistral models
         inference_config, additional_model_request_fields = (
             _prepare_mistral_model_params(model, generation_params)
+        )
+        system_prompts = (
+            [
+                {
+                    "text": "\n\n".join(instructions),
+                }
+            ]
+            if instructions and any(instructions)
+            else []
+        )
+
+    elif is_gpt_oss_model(model):
+        # Special handling for GPT-OSS models
+        inference_config, additional_model_request_fields = (
+            _prepare_gpt_oss_model_params(model, generation_params)
         )
         system_prompts = (
             [

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -190,6 +190,9 @@ BEDROCK_PRICING = {
         "llama3-2-3b-instruct": {"input": 0.00015, "output": 0.00015},
         "llama3-2-11b-instruct": {"input": 0.00016, "output": 0.00016},
         "llama3-2-90b-instruct": {"input": 0.00072, "output": 0.00072},
+        # OpenAI GPT-OSS models
+        "gpt-oss-20b": {"input": 0.00015, "output": 0.00030},
+        "gpt-oss-120b": {"input": 0.00030, "output": 0.00060},
     },
     "ap-northeast-1": {},
     "default": {

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -269,6 +269,9 @@ BEDROCK_PRICING = {
         "llama3-2-3b-instruct": {"input": 0.00015, "output": 0.00015},
         "llama3-2-11b-instruct": {"input": 0.00016, "output": 0.00016},
         "llama3-2-90b-instruct": {"input": 0.00072, "output": 0.00072},
+        # OpenAI GPT-OSS models
+        "gpt-oss-20b": {"input": 0.00015, "output": 0.00030},
+        "gpt-oss-120b": {"input": 0.00030, "output": 0.00060},
     },
     # EU regions (eu-central-1, eu-west-1, eu-west-3)
     "eu-central-1": {

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -32,6 +32,8 @@ type_model_name = Literal[
     "llama3-2-3b-instruct",
     "llama3-2-11b-instruct",
     "llama3-2-90b-instruct",
+    "gpt-oss-20b",
+    "gpt-oss-120b",
 ]
 
 

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -104,4 +104,6 @@ export const AVAILABLE_MODEL_KEYS = [
   'llama3-2-3b-instruct',
   'llama3-2-11b-instruct',
   'llama3-2-90b-instruct',
+  'gpt-oss-20b',
+  'gpt-oss-120b',
 ] as const;

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -215,6 +215,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         description: t('model.gpt-oss-20b.description'),
         supportMediaType: [],
         supportReasoning: true,
+        forceReasoningEnabled: true, // GPT-OSS always return reasoning contents.
       },
       {
         modelId: 'gpt-oss-120b',
@@ -222,6 +223,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         description: t('model.gpt-oss-120b.description'),
         supportMediaType: [],
         supportReasoning: true,
+        forceReasoningEnabled: true, // GPT-OSS always return reasoning contents.
       },
       // Mistral
       {

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -208,6 +208,21 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportMediaType: LLAMA_SUPPORTED_MEDIA_TYPES,
         supportReasoning: false,
       },
+      // OpenAI GPT-OSS models
+      {
+        modelId: 'gpt-oss-20b',
+        label: t('model.gpt-oss-20b.label'),
+        description: t('model.gpt-oss-20b.description'),
+        supportMediaType: [],
+        supportReasoning: true,
+      },
+      {
+        modelId: 'gpt-oss-120b',
+        label: t('model.gpt-oss-120b.label'),
+        description: t('model.gpt-oss-120b.description'),
+        supportMediaType: [],
+        supportReasoning: true,
+      },
       // Mistral
       {
         modelId: 'mistral-7b-instruct',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -127,6 +127,16 @@ const translation = {
         description:
           'Large multimodal model with advanced image understanding and visual reasoning capabilities for sophisticated visual intelligence applications.',
       },
+      'gpt-oss-20b': {
+        label: 'GPT-OSS 20B',
+        description:
+          'Open-weight 20B parameter model with 128K context window and reasoning capabilities.',
+      },
+      'gpt-oss-120b': {
+        label: 'GPT-OSS 120B',
+        description:
+          'Open-weight 120B parameter model with 128K context window and advanced reasoning capabilities.',
+      },
     },
     agent: {
       label: 'Agent',

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -53,6 +53,16 @@ const translation = {
       'mistral-large': {
         label: 'Mistral Grande',
       },
+      'gpt-oss-20b': {
+        label: 'GPT-OSS 20B',
+        description:
+          'Modelo de peso abierto de 20B parámetros con ventana de contexto de 128K y capacidades de razonamiento.',
+      },
+      'gpt-oss-120b': {
+        label: 'GPT-OSS 120B',
+        description:
+          'Modelo de peso abierto de 120B parámetros con ventana de contexto de 128K y capacidades avanzadas de razonamiento.',
+      },
     },
     agent: {
       label: 'Agente',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -128,6 +128,16 @@ const translation: typeof en = {
         description:
           '高度な画像理解と視覚的推論機能を備えた大規模マルチモーダルモデル。複雑な推論と画像テキスト検索に優れた性能を発揮する',
       },
+      'gpt-oss-20b': {
+        label: 'GPT-OSS 20B',
+        description:
+          '128Kコンテキストウィンドウと推論機能を持つオープンウェイト20Bパラメータモデル',
+      },
+      'gpt-oss-120b': {
+        label: 'GPT-OSS 120B',
+        description:
+          '128Kコンテキストウィンドウと高度な推論機能を持つオープンウェイト120Bパラメータモデル',
+      },
     },
     agent: {
       label: 'エージェント',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

• **Added GPT-OSS 20B and 120B models** with 128K context window and reasoning capabilities
• **Backend integration**: Model ID mapping, pricing configuration, and parameter handling
• **Frontend integration**: Model definitions, translations (EN/ES/JA), and UI components
• **Cross-region inference**: Configured for us-west-2 region (GPT-OSS models don't support cross-region inference)
• **Reasoning support**: Always-enabled reasoning like DeepSeek R1 (cannot be disabled by users)
• **Parameter compatibility**: Removed unsupported fields (stopSequences, signature) for GPT-OSS models

### References:
• [OpenAI GPT-OSS models on Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html)
• [Bedrock cross-region inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
