### PR TITLE
Fix: Text is not cleared when the streaming state machine is reset.

### DIFF
--- a/frontend/src/hooks/xstates/streaming.ts
+++ b/frontend/src/hooks/xstates/streaming.ts
@@ -58,6 +58,7 @@ export const streamingStateMachine = setup({
   actions: {
     reset: assign({
       reasoning: '',
+      text: '',
       tools: [],
       relatedDocuments: [],
     }),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the streaming state machine that doesn't clear the text even when received a 'reset' event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
