### PR TITLE
Fix: Select the correct radio button when editing bot with existing KB

### DIFF
--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -131,6 +131,14 @@ const BotKbEditPage: React.FC = () => {
     'new' | 'existing'
   >('new');
 
+  // When loading an existing bot that already has a knowledge base id(s),
+  // default the radio selection to 'existing' so the UI reflects the bot state.
+  useEffect(() => {
+    if (existKnowledgeBaseId && knowledgeBaseType !== 'existing') {
+      setKnowledgeBaseType('existing');
+    }
+  }, [existKnowledgeBaseId, knowledgeBaseType]);
+
   const disabledKnowledgeEdit = useMemo(() => {
     return !!existKnowledgeBaseId;
   }, [existKnowledgeBaseId]);


### PR DESCRIPTION
When editing existing bots the KB radio button wouldn't accurately reflect whether it has existing Knowledge Base or not. This simple patch fixes that.