### PR TITLE
Display pinned bots in Drawer

### DIFF
--- a/frontend/src/@types/bot.d.ts
+++ b/frontend/src/@types/bot.d.ts
@@ -206,7 +206,7 @@ export type GetBotsResponse = BotListItem[];
 
 export type GetMyBotResponse = BotDetails;
 
-export type GetPinnedBotResponse = BotMeta[];
+export type GetPinnedBotResponse = BotListItem[];
 
 export type GetBotSummaryResponse = BotSummary;
 

--- a/frontend/src/@types/common.d.ts
+++ b/frontend/src/@types/common.d.ts
@@ -8,4 +8,13 @@ export type DrawerOptions = {
     recentlyUsedBots: number;
     conversationHistory: number;
   };
+  show: {
+    newChat: boolean;
+    myBots: boolean;
+    discoverBots: boolean;
+    pinnedBots: boolean;
+    starredBots: boolean;
+    recentlyUsedBots: boolean;
+    conversationHistory: boolean;
+  };
 };

--- a/frontend/src/components/DialogDrawerOptions.tsx
+++ b/frontend/src/components/DialogDrawerOptions.tsx
@@ -4,6 +4,7 @@ import Button from './Button';
 import ModalDialog from './ModalDialog';
 import { useTranslation } from 'react-i18next';
 import InputText from './InputText';
+import Toggle from './Toggle';
 
 type Props = BaseProps & {
   isOpen: boolean;
@@ -23,6 +24,14 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
     number | null
   >(0);
 
+  const [showNewChat, setShowNewChat] = useState(true);
+  const [showMyBots, setShowMyBots] = useState(true);
+  const [showDiscoverBots, setShowDiscoverBots] = useState(true);
+  const [showPinnedBots, setShowPinnedBots] = useState(true);
+  const [showStarredBots, setShowStarredBots] = useState(true);
+  const [showRecentlyUsedBots, setShowRecentlyUsedBots] = useState(true);
+  const [showConversationHistory, setShowConversationHistory] = useState(true);
+
   useEffect(() => {
     if (props.isOpen) {
       setStarredBotsCount(props.drawerOptions.displayCount.starredBots);
@@ -32,6 +41,13 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
       setConversationHistoryCount(
         props.drawerOptions.displayCount.conversationHistory
       );
+      setShowNewChat(props.drawerOptions.show.newChat);
+      setShowMyBots(props.drawerOptions.show.myBots);
+      setShowDiscoverBots(props.drawerOptions.show.discoverBots);
+      setShowPinnedBots(props.drawerOptions.show.pinnedBots);
+      setShowStarredBots(props.drawerOptions.show.starredBots);
+      setShowRecentlyUsedBots(props.drawerOptions.show.recentlyUsedBots);
+      setShowConversationHistory(props.drawerOptions.show.conversationHistory);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.isOpen]);
@@ -82,6 +98,49 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
       <div className="flex flex-col gap-3">
         <div>
           <div className="text-base font-bold">
+            {t('drawerOptionsDialog.label.visibility')}
+          </div>
+          <div className="ml-3 mt-1 flex flex-col gap-1">
+            <Toggle
+              label={t('button.newChat')}
+              value={showNewChat}
+              onChange={setShowNewChat}
+            />
+            <Toggle
+              label={t('app.myBots')}
+              value={showMyBots}
+              onChange={setShowMyBots}
+            />
+            <Toggle
+              label={t('app.discoverBots')}
+              value={showDiscoverBots}
+              onChange={setShowDiscoverBots}
+            />
+            <Toggle
+              label={t('app.pinnedBots')}
+              value={showPinnedBots}
+              onChange={setShowPinnedBots}
+            />
+            <Toggle
+              label={t('app.starredBots')}
+              value={showStarredBots}
+              onChange={setShowStarredBots}
+            />
+            <Toggle
+              label={t('app.recentlyUsedBots')}
+              value={showRecentlyUsedBots}
+              onChange={setShowRecentlyUsedBots}
+            />
+            <Toggle
+              label={t('app.conversationHistory')}
+              value={showConversationHistory}
+              onChange={setShowConversationHistory}
+            />
+          </div>
+        </div>
+
+        <div>
+          <div className="text-base font-bold">
             {t('drawerOptionsDialog.label.displayCount')}
           </div>
           <div className="ml-3 mt-1 flex flex-col gap-2">
@@ -90,6 +149,7 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
               type="number"
               value={starredBotsCount?.toString() ?? ''}
               errorMessage={errorMessages['starredBots']}
+              disabled={!showStarredBots}
               onChange={(s) => {
                 setStarredBotsCount(s === '' ? null : parseInt(s));
               }}
@@ -99,6 +159,7 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
               type="number"
               value={recentlyUsedBotsCount?.toString() ?? ''}
               errorMessage={errorMessages['recentlyUsedBots']}
+              disabled={!showRecentlyUsedBots}
               onChange={(s) => {
                 setRecentlyUsedBotsCount(s === '' ? null : parseInt(s));
               }}
@@ -108,6 +169,7 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
               type="number"
               value={conversationHistoryCount?.toString() ?? ''}
               errorMessage={errorMessages['conversationHistory']}
+              disabled={!showConversationHistory}
               onChange={(s) => {
                 setConversationHistoryCount(s === '' ? null : parseInt(s));
               }}
@@ -128,6 +190,15 @@ const DialogDrawerOptions: React.FC<Props> = (props) => {
                 starredBots: starredBotsCount!,
                 recentlyUsedBots: recentlyUsedBotsCount!,
                 conversationHistory: conversationHistoryCount!,
+              },
+              show: {
+                newChat: showNewChat,
+                myBots: showMyBots,
+                discoverBots: showDiscoverBots,
+                pinnedBots: showPinnedBots,
+                starredBots: showStarredBots,
+                recentlyUsedBots: showRecentlyUsedBots,
+                conversationHistory: showConversationHistory,
               },
             });
           }}

--- a/frontend/src/components/Drawer.tsx
+++ b/frontend/src/components/Drawer.tsx
@@ -45,6 +45,7 @@ import IconPinnedBot from './IconPinnedBot';
 type Props = BaseProps & {
   isAdmin: boolean;
   conversations?: ConversationMeta[];
+  pinnedBots?: BotListItem[];
   starredBots?: BotListItem[];
   recentlyUsedUnstarredBots?: BotListItem[];
   updateConversationTitle: (
@@ -202,7 +203,7 @@ const Drawer: React.FC<Props> = (props) => {
   const navigate = useNavigate();
   const { getPageLabel } = usePageLabel();
   const { opened, switchOpen, drawerOptions } = useDrawer();
-  const { conversations, starredBots, recentlyUsedUnstarredBots } = props;
+  const { conversations, pinnedBots, starredBots, recentlyUsedUnstarredBots } = props;
 
   const location = useLocation();
 
@@ -309,6 +310,25 @@ const Drawer: React.FC<Props> = (props) => {
                 labelComponent={getPageLabel('/bot/discover')}
                 onClick={closeSmallDrawer}
               />
+
+              {pinnedBots?.filter((bot) => bot.available).length ? (
+                <ExpandableDrawerGroup
+                  label={t('app.pinnedBots')}
+                  className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark">
+                  {pinnedBots
+                    .filter((bot) => bot.available)
+                    .map((bot) => (
+                      <DrawerItem
+                        key={bot.id}
+                        isActive={botId === bot.id && !conversationId}
+                        to={`/bot/${bot.id}`}
+                        icon={<IconPinnedBot showAlways />}
+                        labelComponent={bot.title}
+                        onClick={onClickNewBotChat}
+                      />
+                    ))}
+                </ExpandableDrawerGroup>
+              ) : null}
 
               <ExpandableDrawerGroup
                 label={t('app.starredBots')}

--- a/frontend/src/components/Drawer.tsx
+++ b/frontend/src/components/Drawer.tsx
@@ -289,180 +289,193 @@ const Drawer: React.FC<Props> = (props) => {
           } text-sm  text-white transition-width`}>
           {!isAdminPanel && (
             <>
-              <DrawerItem
-                isActive={false}
-                icon={<PiNotePencil />}
-                to="/"
-                onClick={onClickNewChat}
-                labelComponent={t('button.newChat')}
-              />
-              <DrawerItem
-                isActive={false}
-                icon={<PiListBullets />}
-                to="/bot/my"
-                labelComponent={getPageLabel('/bot/my')}
-                onClick={closeSmallDrawer}
-              />
-              <DrawerItem
-                isActive={false}
-                icon={<PiCompass />}
-                to="/bot/discover"
-                labelComponent={getPageLabel('/bot/discover')}
-                onClick={closeSmallDrawer}
-              />
+              {drawerOptions.show.newChat && (
+                <DrawerItem
+                  isActive={false}
+                  icon={<PiNotePencil />}
+                  to="/"
+                  onClick={onClickNewChat}
+                  labelComponent={t('button.newChat')}
+                />
+              )}
+              {drawerOptions.show.myBots && (
+                <DrawerItem
+                  isActive={false}
+                  icon={<PiListBullets />}
+                  to="/bot/my"
+                  labelComponent={getPageLabel('/bot/my')}
+                  onClick={closeSmallDrawer}
+                />
+              )}
+              {drawerOptions.show.discoverBots && (
+                <DrawerItem
+                  isActive={false}
+                  icon={<PiCompass />}
+                  to="/bot/discover"
+                  labelComponent={getPageLabel('/bot/discover')}
+                  onClick={closeSmallDrawer}
+                />
+              )}
 
-              {pinnedBots?.filter((bot) => bot.available).length ? (
+              {drawerOptions.show.pinnedBots &&
+                pinnedBots?.filter((bot) => bot.available).length ? (
+                  <ExpandableDrawerGroup
+                    label={t('app.pinnedBots')}
+                    className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark">
+                    {pinnedBots
+                      .filter((bot) => bot.available)
+                      .map((bot) => (
+                        <DrawerItem
+                          key={bot.id}
+                          isActive={botId === bot.id && !conversationId}
+                          to={`/bot/${bot.id}`}
+                          icon={<IconPinnedBot showAlways />}
+                          labelComponent={bot.title}
+                          onClick={onClickNewBotChat}
+                        />
+                      ))}
+                  </ExpandableDrawerGroup>
+                ) : null}
+
+              {drawerOptions.show.starredBots && (
                 <ExpandableDrawerGroup
-                  label={t('app.pinnedBots')}
+                  label={t('app.starredBots')}
                   className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark">
-                  {pinnedBots
-                    .filter((bot) => bot.available)
+                  {starredBots === undefined && (
+                    <div className="flex flex-col gap-2 p-2">
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                    </div>
+                  )}
+                  {starredBots
+                    ?.slice(0, drawerOptions.displayCount.starredBots)
                     .map((bot) => (
                       <DrawerItem
                         key={bot.id}
                         isActive={botId === bot.id && !conversationId}
                         to={`/bot/${bot.id}`}
-                        icon={<IconPinnedBot showAlways />}
+                        icon={
+                          isPinnedBot(bot.sharedStatus) ? (
+                            <IconPinnedBot showAlways />
+                          ) : (
+                            <PiRobot />
+                          )
+                        }
                         labelComponent={bot.title}
                         onClick={onClickNewBotChat}
                       />
                     ))}
+
+                  {starredBots && starredBots.length > 15 && (
+                    <Button
+                      text
+                      rightIcon={<PiArrowRight />}
+                      className="w-full"
+                      onClick={() => {
+                        navigate('/bot/starred');
+                        closeSmallDrawer();
+                      }}>
+                      {t('bot.button.viewAll')}
+                    </Button>
+                  )}
                 </ExpandableDrawerGroup>
-              ) : null}
+              )}
 
-              <ExpandableDrawerGroup
-                label={t('app.starredBots')}
-                className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark">
-                {starredBots === undefined && (
-                  <div className="flex flex-col gap-2 p-2">
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                  </div>
-                )}
-                {starredBots
-                  ?.slice(0, drawerOptions.displayCount.starredBots)
-                  .map((bot) => (
-                    <DrawerItem
-                      key={bot.id}
-                      isActive={botId === bot.id && !conversationId}
-                      to={`/bot/${bot.id}`}
-                      icon={
-                        isPinnedBot(bot.sharedStatus) ? (
-                          <IconPinnedBot showAlways />
-                        ) : (
-                          <PiRobot />
-                        )
-                      }
-                      labelComponent={bot.title}
-                      onClick={onClickNewBotChat}
-                    />
-                  ))}
+              {drawerOptions.show.recentlyUsedBots && (
+                <ExpandableDrawerGroup
+                  label={t('app.recentlyUsedBots')}
+                  className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark ">
+                  {recentlyUsedUnstarredBots === undefined && (
+                    <div className="flex flex-col gap-2 p-2">
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                    </div>
+                  )}
+                  {recentlyUsedUnstarredBots
+                    ?.slice(0, drawerOptions.displayCount.recentlyUsedBots)
+                    .map((bot) => (
+                      <DrawerItem
+                        key={bot.id}
+                        isActive={false}
+                        to={`/bot/${bot.id}`}
+                        icon={
+                          isPinnedBot(bot.sharedStatus) ? (
+                            <IconPinnedBot showAlways />
+                          ) : (
+                            <PiRobot />
+                          )
+                        }
+                        labelComponent={bot.title}
+                        onClick={onClickNewBotChat}
+                      />
+                    ))}
 
-                {starredBots && starredBots.length > 15 && (
-                  <Button
-                    text
-                    rightIcon={<PiArrowRight />}
-                    className="w-full"
-                    onClick={() => {
-                      navigate('/bot/starred');
-                      closeSmallDrawer();
-                    }}>
-                    {t('bot.button.viewAll')}
-                  </Button>
-                )}
-              </ExpandableDrawerGroup>
+                  {recentlyUsedUnstarredBots && (
+                    <Button
+                      text
+                      rightIcon={<PiArrowRight />}
+                      className="w-full"
+                      onClick={() => {
+                        navigate('/bot/recently-used');
+                        closeSmallDrawer();
+                      }}>
+                      {t('bot.button.viewAll')}
+                    </Button>
+                  )}
+                </ExpandableDrawerGroup>
+              )}
 
-              <ExpandableDrawerGroup
-                label={t('app.recentlyUsedBots')}
-                className="border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark ">
-                {recentlyUsedUnstarredBots === undefined && (
-                  <div className="flex flex-col gap-2 p-2">
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                  </div>
-                )}
-                {recentlyUsedUnstarredBots
-                  ?.slice(0, drawerOptions.displayCount.recentlyUsedBots)
-                  .map((bot) => (
-                    <DrawerItem
-                      key={bot.id}
-                      isActive={false}
-                      to={`/bot/${bot.id}`}
-                      icon={
-                        isPinnedBot(bot.sharedStatus) ? (
-                          <IconPinnedBot showAlways />
-                        ) : (
-                          <PiRobot />
-                        )
-                      }
-                      labelComponent={bot.title}
-                      onClick={onClickNewBotChat}
-                    />
-                  ))}
+              {drawerOptions.show.conversationHistory && (
+                <ExpandableDrawerGroup
+                  label={t('app.conversationHistory')}
+                  className={twMerge(
+                    'border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark',
+                    props.isAdmin ? 'mb-20' : 'mb-10'
+                  )}>
+                  {conversations === undefined && (
+                    <div className="flex flex-col gap-2 p-2">
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                      <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
+                    </div>
+                  )}
+                  {conversations
+                    ?.slice(0, drawerOptions.displayCount.conversationHistory)
+                    .map((conversation, idx) => (
+                      <Item
+                        key={idx}
+                        className="grow"
+                        label={conversation.title}
+                        conversationId={conversation.id}
+                        generatedTitle={idx === generateTitleIndex}
+                        updateTitle={props.updateConversationTitle}
+                        onClick={closeSmallDrawer}
+                        onDelete={() => props.onDeleteConversation(conversation)}
+                      />
+                    ))}
 
-                {recentlyUsedUnstarredBots && (
-                  <Button
-                    text
-                    rightIcon={<PiArrowRight />}
-                    className="w-full"
-                    onClick={() => {
-                      navigate('/bot/recently-used');
-                      closeSmallDrawer();
-                    }}>
-                    {t('bot.button.viewAll')}
-                  </Button>
-                )}
-              </ExpandableDrawerGroup>
-
-              <ExpandableDrawerGroup
-                label={t('app.conversationHistory')}
-                className={twMerge(
-                  'border-t bg-aws-squid-ink-light pt-1 dark:bg-aws-squid-ink-dark',
-                  props.isAdmin ? 'mb-20' : 'mb-10'
-                )}>
-                {conversations === undefined && (
-                  <div className="flex flex-col gap-2 p-2">
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                    <Skeleton className="h-10 w-full bg-aws-sea-blue-light/50 dark:bg-aws-sea-blue-dark/50" />
-                  </div>
-                )}
-                {conversations
-                  ?.slice(0, drawerOptions.displayCount.conversationHistory)
-                  .map((conversation, idx) => (
-                    <Item
-                      key={idx}
-                      className="grow"
-                      label={conversation.title}
-                      conversationId={conversation.id}
-                      generatedTitle={idx === generateTitleIndex}
-                      updateTitle={props.updateConversationTitle}
-                      onClick={closeSmallDrawer}
-                      onDelete={() => props.onDeleteConversation(conversation)}
-                    />
-                  ))}
-
-                {conversations && (
-                  <Button
-                    text
-                    rightIcon={<PiArrowRight />}
-                    className="w-full"
-                    onClick={() => {
-                      navigate('/conversations');
-                      closeSmallDrawer();
-                    }}>
-                    {t('bot.button.viewAll')}
-                  </Button>
-                )}
-              </ExpandableDrawerGroup>
+                  {conversations && (
+                    <Button
+                      text
+                      rightIcon={<PiArrowRight />}
+                      className="w-full"
+                      onClick={() => {
+                        navigate('/conversations');
+                        closeSmallDrawer();
+                      }}>
+                      {t('bot.button.viewAll')}
+                    </Button>
+                  )}
+                </ExpandableDrawerGroup>
+              )}
             </>
           )}
 

--- a/frontend/src/features/discover/hooks/useBotStore.ts
+++ b/frontend/src/features/discover/hooks/useBotStore.ts
@@ -1,6 +1,6 @@
 import useBotApi from '../../../hooks/useBotApi';
 import useBotStoreApi from './useBotStoreApi';
-import { BotMeta } from '../../../@types/bot';
+import { BotListItem, BotMeta } from '../../../@types/bot';
 import { useCallback } from 'react';
 
 const useBotStore = () => {
@@ -31,7 +31,7 @@ const useBotStore = () => {
       // Update pinnedBots
       if (pinnedBots) {
         mutatePinnedBots(
-          pinnedBots.map((bot: BotMeta) =>
+          pinnedBots.map((bot: BotListItem) =>
             bot.id === botId ? { ...bot, isStarred } : bot
           ),
           false

--- a/frontend/src/hooks/useBot.ts
+++ b/frontend/src/hooks/useBot.ts
@@ -32,6 +32,11 @@ const useBot = (shouldAutoRefreshMyBots?: boolean) => {
   });
 
   const {
+    data: pinnedBots,
+    mutate: mutatePinnedBots,
+  } = api.getPinnedBots();
+
+  const {
     data: recentlyUsedBots,
     mutate: mutateRecentlyUsedBots,
     isLoading: isLoadingRecentlyUsedBots,
@@ -44,6 +49,8 @@ const useBot = (shouldAutoRefreshMyBots?: boolean) => {
     myBots,
     mutateMyBots,
     isLoadingMyBots,
+    pinnedBots: pinnedBots?.filter((bot) => bot.available),
+    mutatePinnedBots,
     starredBots: starredBots?.filter((bot) => bot.available),
     mutateStarredBots,
     recentlyUsedBots,

--- a/frontend/src/hooks/useDrawer.ts
+++ b/frontend/src/hooks/useDrawer.ts
@@ -7,6 +7,15 @@ const DEFAULT_OPTIONS: DrawerOptions = {
     recentlyUsedBots: 15,
     conversationHistory: 5,
   },
+  show: {
+    newChat: true,
+    myBots: true,
+    discoverBots: true,
+    pinnedBots: true,
+    starredBots: true,
+    recentlyUsedBots: true,
+    conversationHistory: true,
+  },
 };
 
 const useDrawerStore = create<{
@@ -20,7 +29,18 @@ const useDrawerStore = create<{
   try {
     const savedOptions = localStorage.getItem('DrawerOptions');
     if (savedOptions) {
-      initialOptions = JSON.parse(savedOptions);
+      const parsed = JSON.parse(savedOptions);
+      // Merge with defaults to handle migration from old structure
+      initialOptions = {
+        displayCount: {
+          ...DEFAULT_OPTIONS.displayCount,
+          ...(parsed.displayCount || {}),
+        },
+        show: {
+          ...DEFAULT_OPTIONS.show,
+          ...(parsed.show || {}),
+        },
+      };
     }
   } catch (e) {
     console.error('Failed to parse DrawerOptions from localStorage', e);

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -3,6 +3,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Nachricht senden',
+      pinnedBots: 'Angeheftete Bots',
       starredBots: 'Favorisierte Bots',
       recentlyUsedBots: 'Zuletzt genutzte Bots',
       conversationHistory: 'Verlauf',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'How can I Help You?',
+      pinnedBots: 'Pinned Bots',
       starredBots: 'Starred Bots',
       recentlyUsedBots: 'Recently Used Bots',
       conversationHistory: 'Recent Chats',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -8,6 +8,8 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'How can I Help You?',
+      myBots: 'My Bots',
+      discoverBots: 'Discover Bots',
       pinnedBots: 'Pinned Bots',
       starredBots: 'Starred Bots',
       recentlyUsedBots: 'Recently Used Bots',
@@ -646,6 +648,7 @@ How would you categorize this email?`,
     drawerOptionsDialog: {
       title: 'Side Menu Options',
       label: {
+        visibility: 'Visibility',
         displayCount: 'Display Count',
       },
     },

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Chat Bedrock',
       inputMessage: 'Enviar un mensaje',
+      pinnedBots: 'Bots Fijados',
       starredBots: 'Bots Favoritos',
       recentlyUsedBots: 'Bots Usados Recientemente',
       conversationHistory: 'Historial',

--- a/frontend/src/i18n/fr/index.ts
+++ b/frontend/src/i18n/fr/index.ts
@@ -3,6 +3,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Envoyer un message',
+      pinnedBots: 'Bots épinglés',
       starredBots: 'Epingler un bot',
       recentlyUsedBots: 'Bot utilisé récemment',
       conversationHistory: 'Historique',

--- a/frontend/src/i18n/id/index.ts
+++ b/frontend/src/i18n/id/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Bisakah Saya Membantu Anda?',
+      pinnedBots: 'Bot yang Dipin',
       starredBots: 'Bot Favorit',
       recentlyUsedBots: 'Bot yang Baru Digunakan',
       conversationHistory: 'Riwayat',

--- a/frontend/src/i18n/it/index.ts
+++ b/frontend/src/i18n/it/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Inviare un messaggio',
+      pinnedBots: 'Bot fissati',
       starredBots: 'Bot preferiti',
       recentlyUsedBots: 'Bot utilizzati di recente',
       conversationHistory: 'Cronologia',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -11,6 +11,7 @@ const translation: typeof en = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'お手伝いできることはありますか？',
+      pinnedBots: 'ピン留めボット',
       starredBots: 'スター付きのボット',
       recentlyUsedBots: '最近使用したボット',
       conversationHistory: '最近のチャット',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -11,6 +11,8 @@ const translation: typeof en = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'お手伝いできることはありますか？',
+      myBots: 'マイボット',
+      discoverBots: 'ボットを探す',
       pinnedBots: 'ピン留めボット',
       starredBots: 'スター付きのボット',
       recentlyUsedBots: '最近使用したボット',
@@ -652,6 +654,7 @@ const translation: typeof en = {
     drawerOptionsDialog: {
       title: 'サイドメニューオプション',
       label: {
+        visibility: '表示設定',
         displayCount: '表示数',
       },
     },

--- a/frontend/src/i18n/ko/index.ts
+++ b/frontend/src/i18n/ko/index.ts
@@ -6,6 +6,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: '입력해 주십시오',
+      pinnedBots: '고정된 봇',
     },
     deleteDialog: {
       title: '삭제 확인',

--- a/frontend/src/i18n/ms/index.ts
+++ b/frontend/src/i18n/ms/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Bolehkah Saya Membantu Anda?',
+      pinnedBots: 'Bot yang Disemat',
       starredBots: 'Bot Berbintang',
       recentlyUsedBots: 'Bot Yang Baru Digunakan',
       conversationHistory: 'Sejarah',

--- a/frontend/src/i18n/nb/index.ts
+++ b/frontend/src/i18n/nb/index.ts
@@ -9,6 +9,7 @@ const translation = {
       name: 'ACO-gpt',
       nameWithoutClaude: 'ACO-gpt',
       inputMessage: 'Send en melding',
+      pinnedBots: 'Faste boter',
       starredBots: 'Favorittbot',
       recentlyUsedBots: 'Nylig brukte boter',
       conversationHistory: 'Historikk',
@@ -36,6 +37,7 @@ const translation = {
         app: {
           name: 'Bedrock Chat',
           inputMessage: 'Send en melding',
+          pinnedBots: 'Faste boter',
           starredBots: 'Favorittbot',
           recentlyUsedBots: 'Nylig brukte boter',
           conversationHistory: 'Historikk',

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Jak mogę pomóc?',
+      pinnedBots: 'Przypięte boty',
       starredBots: 'Ulubione Boty',
       recentlyUsedBots: 'Ostatnio używane Boty',
       conversationHistory: 'Historia',

--- a/frontend/src/i18n/pt-br/index.ts
+++ b/frontend/src/i18n/pt-br/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Como posso te ajudar?',
+      pinnedBots: 'Bots Fixados',
       starredBots: 'Bots Favoritos',
       recentlyUsedBots: 'Bots Usados Recentemente',
       conversationHistory: 'Conversas Recentes',

--- a/frontend/src/i18n/th/index.ts
+++ b/frontend/src/i18n/th/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'ฉันช่วยอะไรคุณได้บ้าง?',
+      pinnedBots: 'บ็อตที่ปักหมุด',
       starredBots: 'บ็อตที่ถูกใจ',
       recentlyUsedBots: 'บ็อตที่ใช้งานล่าสุด',
       conversationHistory: 'ประวัติ',

--- a/frontend/src/i18n/vi/index.ts
+++ b/frontend/src/i18n/vi/index.ts
@@ -8,6 +8,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: 'Tôi có thể giúp gì cho bạn?',
+      pinnedBots: 'Bot Ghim',
       starredBots: 'Bot Yêu Thích',
       recentlyUsedBots: 'Bot Đã Dùng Gần Đây',
       conversationHistory: 'Lịch sử',

--- a/frontend/src/i18n/zh-hans/index.ts
+++ b/frontend/src/i18n/zh-hans/index.ts
@@ -6,6 +6,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: '请输入',
+      pinnedBots: '置顶 Bots',
       starredBots: '我的 Bots 收藏',
       recentlyUsedBots: '最近使用过的 Bots',
       conversationHistory: '交谈纪录',

--- a/frontend/src/i18n/zh-hant/index.ts
+++ b/frontend/src/i18n/zh-hant/index.ts
@@ -6,6 +6,7 @@ const translation = {
     app: {
       name: 'Bedrock Chat',
       inputMessage: '請輸入訊息',
+      pinnedBots: '置頂 Bots',
       starredBots: '我的最愛 Bots',
       recentlyUsedBots: '最近用過的 Bots',
       conversationHistory: '交談紀錄',

--- a/frontend/src/layouts/AppContent.tsx
+++ b/frontend/src/layouts/AppContent.tsx
@@ -38,7 +38,7 @@ const AppContent: React.FC<Props> = (props) => {
     deleteConversation,
     clearConversations: clear,
   } = useConversation();
-  const { starredBots, recentlyUsedUnstarredBots } = useBot();
+  const { pinnedBots, starredBots, recentlyUsedUnstarredBots } = useBot();
   const { newChat, isGeneratedTitle } = useChat();
   const { isConversationOrNewChat, pathPattern } = usePageTitlePathPattern();
   const { isAdmin } = useLoginUser();
@@ -92,6 +92,7 @@ const AppContent: React.FC<Props> = (props) => {
     <div className="relative flex h-dvh w-screen bg-aws-paper-light dark:bg-aws-paper-dark">
       <Drawer
         isAdmin={isAdmin}
+        pinnedBots={pinnedBots}
         conversations={conversations}
         starredBots={starredBots}
         recentlyUsedUnstarredBots={recentlyUsedUnstarredBots}


### PR DESCRIPTION
Pinned ("Essential") bots should show in the left-hand side column by default for unified user experience. All users should have a no-friction access to these bots.

This patch creates a new section in the Drawer and displays the essential bots.

<img width="255" height="280" alt="image" src="https://github.com/user-attachments/assets/5dbdf0f2-be7a-4ed1-af54-a4558319618e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
