### PR TITLE
Fix screen reset bug

### DIFF
--- a/frontend/src/hooks/xstates/streaming.ts
+++ b/frontend/src/hooks/xstates/streaming.ts
@@ -175,8 +175,6 @@ export const streamingStateMachine = setup({
           actions: 'reset',
         },
         goodbye: {
-          // Don't reset on goodbye - we want to preserve the final content!
-          // The subscription will keep the last text state before unsubscribing.
           target: 'leaving',
         },
       },

--- a/frontend/src/hooks/xstates/streaming.ts
+++ b/frontend/src/hooks/xstates/streaming.ts
@@ -175,7 +175,8 @@ export const streamingStateMachine = setup({
           actions: 'reset',
         },
         goodbye: {
-          actions: 'reset',
+          // Don't reset on goodbye - we want to preserve the final content!
+          // The subscription will keep the last text state before unsubscribing.
           target: 'leaving',
         },
       },


### PR DESCRIPTION
As described in #942 the generated output briefly disappears after the generation is completed and the re-appears again. This simple one-liner fixes the issue but not calling the 'reset' action (which clears everything) in the 'goodbye' state.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
