### PR TITLE
Add Claude 4.5 Haiku support

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -196,10 +196,11 @@ REGIONAL_INFERENCE_PROFILES = {
             "us-east-2": "us",
             "us-west-1": "us",
             "us-west-2": "us",
+            "ap-northeast-1": "jp",
+            "ap-northeast-3": "jp",
             "eu-central-1": "eu",
             "eu-north-1": "eu",
             "eu-west-1": "eu",
-            "eu-west-2": "eu",
             "eu-west-3": "eu",
             "eu-south-1": "eu",
             "eu-south-2": "eu",
@@ -389,6 +390,7 @@ def is_tooluse_supported(model: type_model_name) -> bool:
 def is_specify_both_temperature_and_top_p_supported(model: type_model_name) -> bool:
     return model not in [
         "claude-v4.5-sonnet",
+        "claude-v4.5-haiku",
     ]
 
 

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -58,6 +58,7 @@ BASE_MODEL_IDS = {
     "claude-v4.1-opus": "anthropic.claude-opus-4-1-20250805-v1:0",
     "claude-v4-sonnet": "anthropic.claude-sonnet-4-20250514-v1:0",
     "claude-v4.5-sonnet": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "claude-v4.5-haiku": "anthropic.claude-haiku-4-5-20251001-v1:0",
     "claude-v3-haiku": "anthropic.claude-3-haiku-20240307-v1:0",
     "claude-v3-opus": "anthropic.claude-3-opus-20240229-v1:0",
     "claude-v3.5-sonnet": "anthropic.claude-3-5-sonnet-20240620-v1:0",
@@ -94,6 +95,33 @@ GLOBAL_INFERENCE_PROFILES = {
         ]
     },
     "claude-v4.5-sonnet": {
+        "supported_regions": [
+            "us-west-2",
+            "us-west-1",
+            "us-east-2",
+            "us-east-1",
+            "sa-east-1",
+            "eu-west-3",
+            "eu-west-2",
+            "eu-west-1",
+            "eu-south-2",
+            "eu-south-1",
+            "eu-north-1",
+            "eu-central-2",
+            "eu-central-1",
+            "ca-central-1",
+            "ap-southeast-4",
+            "ap-southeast-3",
+            "ap-southeast-2",
+            "ap-southeast-1",
+            "ap-south-2",
+            "ap-south-1",
+            "ap-northeast-3",
+            "ap-northeast-2",
+            "ap-northeast-1",
+        ]
+    },
+    "claude-v4.5-haiku": {
         "supported_regions": [
             "us-west-2",
             "us-west-1",
@@ -160,6 +188,21 @@ REGIONAL_INFERENCE_PROFILES = {
             "eu-south-2": "eu",
             "ap-northeast-1": "jp",
             "ap-northeast-3": "jp",
+        }
+    },
+    "claude-v4.5-haiku": {
+        "supported_regions": {
+            "us-east-1": "us",
+            "us-east-2": "us",
+            "us-west-1": "us",
+            "us-west-2": "us",
+            "eu-central-1": "eu",
+            "eu-north-1": "eu",
+            "eu-west-1": "eu",
+            "eu-west-2": "eu",
+            "eu-west-3": "eu",
+            "eu-south-1": "eu",
+            "eu-south-2": "eu",
         }
     },
     "claude-v3-haiku": {
@@ -358,6 +401,7 @@ def is_prompt_caching_supported(
             "claude-v4.1-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
+            "claude-v4.5-haiku",
             "claude-v3.7-sonnet",
             "claude-v3.5-sonnet-v2",
             "claude-v3.5-haiku",
@@ -369,6 +413,7 @@ def is_prompt_caching_supported(
             "claude-v4.1-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
+            "claude-v4.5-haiku",
             "claude-v3.7-sonnet",
             "claude-v3.5-sonnet-v2",
             "claude-v3.5-haiku",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -87,6 +87,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.00375,
             "cache_read_input": 0.0003,
         },
+        "claude-v4.5-haiku": {
+            "input": 0.001,
+            "output": 0.005,
+            "cache_write_input": 0.00125,
+            "cache_read_input": 0.0001,
+        },
         "claude-v3-haiku": {"input": 0.00025, "output": 0.00125},
         "claude-v3.5-haiku": {
             "input": 0.001,
@@ -166,6 +172,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.00375,
             "cache_read_input": 0.0003,
         },
+        "claude-v4.5-haiku": {
+            "input": 0.001,
+            "output": 0.005,
+            "cache_write_input": 0.00125,
+            "cache_read_input": 0.0001,
+        },
         "claude-v3.7-sonnet": {
             "input": 0.00300,
             "output": 0.01500,
@@ -231,6 +243,12 @@ BEDROCK_PRICING = {
             "output": 0.015,
             "cache_write_input": 0.00375,
             "cache_read_input": 0.0003,
+        },
+        "claude-v4.5-haiku": {
+            "input": 0.001,
+            "output": 0.005,
+            "cache_write_input": 0.00125,
+            "cache_read_input": 0.0001,
         },
         "claude-v3-haiku": {"input": 0.00025, "output": 0.00125},
         "claude-v3.5-haiku": {

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -10,6 +10,7 @@ type_model_name = Literal[
     "claude-v4.1-opus",
     "claude-v4-sonnet",
     "claude-v4.5-sonnet",
+    "claude-v4.5-haiku",
     "claude-v3.5-sonnet",
     "claude-v3.5-sonnet-v2",
     "claude-v3.7-sonnet",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -86,6 +86,7 @@ export const AVAILABLE_MODEL_KEYS = [
   'claude-v4.1-opus',
   'claude-v4-sonnet',
   'claude-v4.5-sonnet',
+  'claude-v4.5-haiku',
   'claude-v3-opus',
   'claude-v3.5-sonnet',
   'claude-v3.5-sonnet-v2',

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -107,6 +107,13 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportReasoning: true,
       },
       {
+        modelId: 'claude-v4.5-haiku',
+        label: t('model.claude-v4.5-haiku.label'),
+        description: t('model.claude-v4.5-haiku.description'),
+        supportMediaType: CLAUDE_SUPPORTED_MEDIA_TYPES,
+        supportReasoning: true,
+      },
+      {
         modelId: 'claude-v3-haiku',
         label: t('model.claude-v3-haiku.label'),
         description: t('model.claude-v3-haiku.description'),

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -37,6 +37,11 @@ const translation = {
         description:
           'The latest version of the Sonnet model that achieves the highest level of coding performance and extended task processing',
       },
+      'claude-v4.5-haiku': {
+        label: 'Claude 4.5 (Haiku)',
+        description:
+          'The fastest and most intelligent Haiku model with near-frontier performance and extended thinking capabilities',
+      },
       'claude-v3-haiku': {
         label: 'Claude 3 (Haiku)',
         description:

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -40,6 +40,11 @@ const translation: typeof en = {
         description:
           'Sonnetの最新版。Claudeモデル最高レベルのコーディング性能と長時間タスク処理が可能',
       },
+      'claude-v4.5-haiku': {
+        label: 'Claude 4.5 (Haiku)',
+        description:
+          'Haikuシリーズ最速かつ最高性能。フロンティアレベルの性能と拡張思考機能を搭載',
+      },
       'claude-v3-haiku': {
         label: 'Claude 3 (Haiku)',
         description:


### PR DESCRIPTION
*Issue #, if available:*
Closes #952 

*Description of changes:*
• Add model ID of Claude 4.5 Haiku (anthropic.claude-haiku-4-5-20251001-v1:0)
• Add support for global and regional inference profiles (US and EU regions only)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
