### PR TITLE
Add support for defaultModel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,35 @@ To configure change the following settings in `cdk.json` or `parameters.ts`:
 "enableBedrockCrossRegionInference": false,
 ```
 
+### Configure Default Models
+
+By default, the application uses `claude-v3.7-sonnet` as the default model for new chat conversations and `claude-v3-haiku` for generating conversation titles. However, some AWS accounts may not have access to these specific models, or you may prefer to use different models as defaults.
+
+You can configure the default models using the following parameters in `parameter.ts`:
+
+```typescript
+bedrockChatParams.set("default", {
+  // Model selected by default when users start a new chat
+  defaultModel: "claude-v3.7-sonnet",
+  
+  // Model used for generating conversation titles (cost optimization)
+  titleModel: "claude-v3-haiku",
+});
+```
+
+- **defaultModel** (optional): The model pre-selected in the chat UI when users start a new conversation. If not set, defaults to `claude-v3.7-sonnet`.
+- **titleModel** (optional): The model used to automatically generate conversation titles. If not set, falls back to `defaultModel`, then to `claude-v3-haiku`.
+
+**When to configure these settings:**
+
+- Your AWS account doesn't have access to the default models (`claude-v3.7-sonnet` or `claude-v3-haiku`)
+- You want to use a different model as the default for your users
+- You want to optimize costs by using a cheaper model (like `claude-v3-haiku` or `amazon-nova-lite`) for title generation
+- You want to use the same model for both chat and title generation for consistency
+
+> [!Note]
+> The `titleModel` is only used internally for generating short conversation titles. Using a smaller, cheaper model for this purpose is recommended as it reduces costs without affecting the user's chat experience.
+
 ### Lambda SnapStart
 
 [Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) improves cold start times for Lambda functions, providing faster response times for better user experience. On the other hand, for Python functions, there is a [charge depending on cache size](https://aws.amazon.com/lambda/pricing/#SnapStart_Pricing) and [not available in some regions](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html#snapstart-supported-regions) currently. To disable SnapStart, edit `cdk.json`.

--- a/backend/app/routes/global_config.py
+++ b/backend/app/routes/global_config.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.usecases.global_config import (
     get_logo_path,
     get_global_available_models,
+    get_default_model,
 )
 
 router = APIRouter(tags=["config"])
@@ -12,8 +13,10 @@ router = APIRouter(tags=["config"])
 def get_global_config():
     """Get global configuration including available models."""
     global_models = get_global_available_models()
+    default_model = get_default_model()
     logo_path = get_logo_path()
     return {
         "globalAvailableModels": global_models,
+        "defaultModel": default_model,
         "logoPath": logo_path,
     }

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -46,7 +46,7 @@ from app.routes.schemas.conversation import (
 )
 from app.stream import ConverseApiStreamHandler, OnStopInput, OnThinking
 from app.usecases.bot import fetch_bot, modify_bot_last_used_time, modify_bot_stats
-from app.usecases.global_config import get_default_model
+from app.usecases.global_config import get_title_model
 from app.user import User
 from app.utils import get_current_time
 from app.vector_search import (
@@ -635,8 +635,8 @@ def propose_conversation_title(
     user_id: str,
     conversation_id: str,
 ) -> str:
-    # Use the configured default model for generating conversation titles
-    model = get_default_model()
+    # Use the configured title model for generating conversation titles
+    model = get_title_model()
 
     PROMPT = """Reading the conversation above, what is the appropriate title for the conversation? When answering the title, please follow the rules below:
 <rules>

--- a/backend/app/usecases/chat.py
+++ b/backend/app/usecases/chat.py
@@ -46,6 +46,7 @@ from app.routes.schemas.conversation import (
 )
 from app.stream import ConverseApiStreamHandler, OnStopInput, OnThinking
 from app.usecases.bot import fetch_bot, modify_bot_last_used_time, modify_bot_stats
+from app.usecases.global_config import get_default_model
 from app.user import User
 from app.utils import get_current_time
 from app.vector_search import (
@@ -633,8 +634,10 @@ def chat_output_from_message(
 def propose_conversation_title(
     user_id: str,
     conversation_id: str,
-    model: type_model_name = "claude-v3-haiku",
 ) -> str:
+    # Use the configured default model for generating conversation titles
+    model = get_default_model()
+
     PROMPT = """Reading the conversation above, what is the appropriate title for the conversation? When answering the title, please follow the rules below:
 <rules>
 - Title length must be from 15 to 20 characters.

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -45,7 +45,7 @@ def get_global_available_models() -> list[str]:
 
 def get_default_model() -> type_model_name:
     """Return the configured default model, falling back to claude-v3.7-sonnet."""
-    return DEFAULT_MODEL or "claude-v3.7-sonnet"  # type: ignore[return-value]
+    return (DEFAULT_MODEL or "").strip() or "claude-v3.7-sonnet"  # type: ignore[return-value]
 
 
 def get_title_model() -> type_model_name:
@@ -53,7 +53,7 @@ def get_title_model() -> type_model_name:
     
     Falls back to: TITLE_MODEL -> DEFAULT_MODEL -> claude-v3-haiku
     """
-    return TITLE_MODEL or DEFAULT_MODEL or "claude-v3-haiku"  # type: ignore[return-value]
+    return (TITLE_MODEL or "").strip() or (DEFAULT_MODEL or "").strip() or "claude-v3-haiku"  # type: ignore[return-value]
 
 
 def get_logo_path() -> str:

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -2,10 +2,13 @@ import json
 import logging
 import os
 
+from app.routes.schemas.conversation import type_model_name
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 GLOBAL_AVAILABLE_MODELS = os.environ.get("GLOBAL_AVAILABLE_MODELS")
+DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL")
 LOGO_PATH = os.environ.get("LOGO_PATH", "")
 
 
@@ -37,6 +40,13 @@ def get_global_available_models() -> list[str]:
 
     logger.info("No global available models configured - all models are available")
     return []
+
+
+def get_default_model() -> type_model_name:
+    """Return the configured default model."""
+    if not DEFAULT_MODEL:
+        raise ValueError("DEFAULT_MODEL environment variable must be set")
+    return DEFAULT_MODEL  # type: ignore[return-value]
 
 
 def get_logo_path() -> str:

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 GLOBAL_AVAILABLE_MODELS = os.environ.get("GLOBAL_AVAILABLE_MODELS")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL")
+TITLE_MODEL = os.environ.get("TITLE_MODEL")
 LOGO_PATH = os.environ.get("LOGO_PATH", "")
 
 
@@ -43,10 +44,16 @@ def get_global_available_models() -> list[str]:
 
 
 def get_default_model() -> type_model_name:
-    """Return the configured default model."""
-    if not DEFAULT_MODEL:
-        raise ValueError("DEFAULT_MODEL environment variable must be set")
-    return DEFAULT_MODEL  # type: ignore[return-value]
+    """Return the configured default model, falling back to claude-v3.7-sonnet."""
+    return DEFAULT_MODEL or "claude-v3.7-sonnet"  # type: ignore[return-value]
+
+
+def get_title_model() -> type_model_name:
+    """Return the model for title generation.
+    
+    Falls back to: TITLE_MODEL -> DEFAULT_MODEL -> claude-v3-haiku
+    """
+    return TITLE_MODEL or DEFAULT_MODEL or "claude-v3-haiku"  # type: ignore[return-value]
 
 
 def get_logo_path() -> str:

--- a/backend/app/usecases/global_config.py
+++ b/backend/app/usecases/global_config.py
@@ -50,7 +50,7 @@ def get_default_model() -> type_model_name:
 
 def get_title_model() -> type_model_name:
     """Return the model for title generation.
-    
+
     Falls back to: TITLE_MODEL -> DEFAULT_MODEL -> claude-v3-haiku
     """
     return (TITLE_MODEL or "").strip() or (DEFAULT_MODEL or "").strip() or "claude-v3-haiku"  # type: ignore[return-value]

--- a/backend/tests/test_usecases/test_global_config.py
+++ b/backend/tests/test_usecases/test_global_config.py
@@ -124,3 +124,123 @@ class TestGetGlobalAvailableModels(unittest.TestCase):
             "GLOBAL_AVAILABLE_MODELS must be a JSON array, got <class 'dict'>"
         )
         self.assertEqual(result, [])
+
+
+class TestGetDefaultModel(unittest.TestCase):
+    """Test cases for get_default_model function."""
+
+    @patch.object(global_config, "DEFAULT_MODEL", "claude-v3.5-sonnet")
+    def test_returns_configured_model(self):
+        """Test that configured DEFAULT_MODEL is returned."""
+        from app.usecases.global_config import get_default_model
+
+        result = get_default_model()
+        self.assertEqual(result, "claude-v3.5-sonnet")
+
+    @patch.object(global_config, "DEFAULT_MODEL", None)
+    def test_falls_back_to_default_when_none(self):
+        """Test that default model is returned when DEFAULT_MODEL is None."""
+        from app.usecases.global_config import get_default_model
+
+        result = get_default_model()
+        self.assertEqual(result, "claude-v3.7-sonnet")
+
+    @patch.object(global_config, "DEFAULT_MODEL", "")
+    def test_falls_back_to_default_when_empty_string(self):
+        """Test that default model is returned when DEFAULT_MODEL is empty string."""
+        from app.usecases.global_config import get_default_model
+
+        result = get_default_model()
+        self.assertEqual(result, "claude-v3.7-sonnet")
+
+    @patch.object(global_config, "DEFAULT_MODEL", "   ")
+    def test_falls_back_to_default_when_whitespace(self):
+        """Test that default model is returned when DEFAULT_MODEL contains only whitespace."""
+        from app.usecases.global_config import get_default_model
+
+        result = get_default_model()
+        self.assertEqual(result, "claude-v3.7-sonnet")
+
+    @patch.object(global_config, "DEFAULT_MODEL", "  amazon-nova-pro  ")
+    def test_strips_whitespace_from_configured_model(self):
+        """Test that whitespace is stripped from configured model."""
+        from app.usecases.global_config import get_default_model
+
+        result = get_default_model()
+        self.assertEqual(result, "amazon-nova-pro")
+
+
+class TestGetTitleModel(unittest.TestCase):
+    """Test cases for get_title_model function."""
+
+    @patch.object(global_config, "TITLE_MODEL", "claude-v3-haiku")
+    @patch.object(global_config, "DEFAULT_MODEL", "claude-v3.7-sonnet")
+    def test_returns_title_model_when_set(self):
+        """Test that TITLE_MODEL is returned when configured."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "claude-v3-haiku")
+
+    @patch.object(global_config, "TITLE_MODEL", None)
+    @patch.object(global_config, "DEFAULT_MODEL", "claude-v3.5-sonnet")
+    def test_falls_back_to_default_model_when_title_model_none(self):
+        """Test that DEFAULT_MODEL is returned when TITLE_MODEL is None."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "claude-v3.5-sonnet")
+
+    @patch.object(global_config, "TITLE_MODEL", "")
+    @patch.object(global_config, "DEFAULT_MODEL", "amazon-nova-lite")
+    def test_falls_back_to_default_model_when_title_model_empty(self):
+        """Test that DEFAULT_MODEL is returned when TITLE_MODEL is empty string."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "amazon-nova-lite")
+
+    @patch.object(global_config, "TITLE_MODEL", None)
+    @patch.object(global_config, "DEFAULT_MODEL", None)
+    def test_falls_back_to_haiku_when_both_none(self):
+        """Test that claude-v3-haiku is returned when both TITLE_MODEL and DEFAULT_MODEL are None."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "claude-v3-haiku")
+
+    @patch.object(global_config, "TITLE_MODEL", "")
+    @patch.object(global_config, "DEFAULT_MODEL", "")
+    def test_falls_back_to_haiku_when_both_empty(self):
+        """Test that claude-v3-haiku is returned when both TITLE_MODEL and DEFAULT_MODEL are empty."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "claude-v3-haiku")
+
+    @patch.object(global_config, "TITLE_MODEL", "   ")
+    @patch.object(global_config, "DEFAULT_MODEL", "   ")
+    def test_falls_back_to_haiku_when_both_whitespace(self):
+        """Test that claude-v3-haiku is returned when both contain only whitespace."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "claude-v3-haiku")
+
+    @patch.object(global_config, "TITLE_MODEL", "  mistral-7b-instruct  ")
+    @patch.object(global_config, "DEFAULT_MODEL", "claude-v3.7-sonnet")
+    def test_strips_whitespace_from_title_model(self):
+        """Test that whitespace is stripped from TITLE_MODEL."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "mistral-7b-instruct")
+
+    @patch.object(global_config, "TITLE_MODEL", "")
+    @patch.object(global_config, "DEFAULT_MODEL", "  llama3-3-70b-instruct  ")
+    def test_strips_whitespace_from_default_model_fallback(self):
+        """Test that whitespace is stripped from DEFAULT_MODEL when used as fallback."""
+        from app.usecases.global_config import get_title_model
+
+        result = get_title_model()
+        self.assertEqual(result, "llama3-3-70b-instruct")

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -103,6 +103,7 @@ const chat = new BedrockChatStack(
     enableBotStoreReplicas: params.enableBotStoreReplicas,
     botStoreLanguage: params.botStoreLanguage,
     globalAvailableModels: params.globalAvailableModels,
+    defaultModel: params.defaultModel,
     tokenValidMinutes: params.tokenValidMinutes,
     devAccessIamRoleArn: params.devAccessIamRoleArn,
     allowedCountries: params.allowedCountries,

--- a/cdk/bin/bedrock-chat.ts
+++ b/cdk/bin/bedrock-chat.ts
@@ -104,6 +104,7 @@ const chat = new BedrockChatStack(
     botStoreLanguage: params.botStoreLanguage,
     globalAvailableModels: params.globalAvailableModels,
     defaultModel: params.defaultModel,
+    titleModel: params.titleModel,
     tokenValidMinutes: params.tokenValidMinutes,
     devAccessIamRoleArn: params.devAccessIamRoleArn,
     allowedCountries: params.allowedCountries,

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -53,6 +53,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly enableBotStoreReplicas: boolean;
   readonly botStoreLanguage: Language;
   readonly globalAvailableModels?: string[];
+  readonly defaultModel?: string;
   readonly tokenValidMinutes: number;
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;
@@ -251,6 +252,7 @@ export class BedrockChatStack extends cdk.Stack {
       enableLambdaSnapStart: props.enableLambdaSnapStart,
       openSearchEndpoint: botStore?.openSearchEndpoint,
       globalAvailableModels: props.globalAvailableModels,
+      defaultModel: props.defaultModel,
       logoPath: props.logoPath,
     });
     props.documentBucket.grantReadWrite(backendApi.handler);

--- a/cdk/lib/bedrock-chat-stack.ts
+++ b/cdk/lib/bedrock-chat-stack.ts
@@ -54,6 +54,7 @@ export interface BedrockChatStackProps extends StackProps {
   readonly botStoreLanguage: Language;
   readonly globalAvailableModels?: string[];
   readonly defaultModel?: string;
+  readonly titleModel?: string;
   readonly tokenValidMinutes: number;
   readonly alternateDomainName?: string;
   readonly hostedZoneId?: string;
@@ -253,6 +254,7 @@ export class BedrockChatStack extends cdk.Stack {
       openSearchEndpoint: botStore?.openSearchEndpoint,
       globalAvailableModels: props.globalAvailableModels,
       defaultModel: props.defaultModel,
+      titleModel: props.titleModel,
       logoPath: props.logoPath,
     });
     props.documentBucket.grantReadWrite(backendApi.handler);

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -47,6 +47,7 @@ export interface ApiProps {
   readonly enableLambdaSnapStart: boolean;
   readonly openSearchEndpoint?: string;
   readonly globalAvailableModels?: string[];
+  readonly defaultModel?: string;
   readonly logoPath?: string;
 }
 
@@ -276,6 +277,7 @@ export class Api extends Construct {
         GLOBAL_AVAILABLE_MODELS: props.globalAvailableModels 
           ? JSON.stringify(props.globalAvailableModels)
           : "[]",
+        DEFAULT_MODEL: props.defaultModel!,
         OPENSEARCH_DOMAIN_ENDPOINT: props.openSearchEndpoint || "",
         LOGO_PATH: props.logoPath || "",
         USE_STRANDS: "true",

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -48,6 +48,7 @@ export interface ApiProps {
   readonly openSearchEndpoint?: string;
   readonly globalAvailableModels?: string[];
   readonly defaultModel?: string;
+  readonly titleModel?: string;
   readonly logoPath?: string;
 }
 
@@ -277,7 +278,8 @@ export class Api extends Construct {
         GLOBAL_AVAILABLE_MODELS: props.globalAvailableModels 
           ? JSON.stringify(props.globalAvailableModels)
           : "[]",
-        DEFAULT_MODEL: props.defaultModel!,
+        DEFAULT_MODEL: props.defaultModel || "",
+        TITLE_MODEL: props.titleModel || "",
         OPENSEARCH_DOMAIN_ENDPOINT: props.openSearchEndpoint || "",
         LOGO_PATH: props.logoPath || "",
         USE_STRANDS: "true",

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -115,6 +115,9 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   // If not configured (empty array), all models are available
   globalAvailableModels: z.array(z.string()).default([]),
 
+  // Default model to be selected when user first visits the app
+  defaultModel: z.string().default("claude-v3.7-sonnet"),
+
   // Frontend branding
   logoPath: z.string().default(""),
 
@@ -269,6 +272,7 @@ export function resolveBedrockChatParameters(
     enableBotStoreReplicas: app.node.tryGetContext("EnableBotStoreReplicas"),
     botStoreLanguage: app.node.tryGetContext("botStoreLanguage"),
     globalAvailableModels: app.node.tryGetContext("globalAvailableModels"),
+    defaultModel: app.node.tryGetContext("defaultModel"),
     logoPath: app.node.tryGetContext("logoPath"),
     devAccessIamRoleArn: app.node.tryGetContext("devAccessIamRoleArn"),
   };

--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -116,7 +116,11 @@ const BedrockChatParametersSchema = BaseParametersSchema.extend({
   globalAvailableModels: z.array(z.string()).default([]),
 
   // Default model to be selected when user first visits the app
-  defaultModel: z.string().default("claude-v3.7-sonnet"),
+  defaultModel: z.string().optional(),
+
+  // Model used for generating conversation titles
+  // (defaults to defaultModel, then a hardcoded default in get_title_model())
+  titleModel: z.string().optional(),
 
   // Frontend branding
   logoPath: z.string().default(""),
@@ -273,6 +277,7 @@ export function resolveBedrockChatParameters(
     botStoreLanguage: app.node.tryGetContext("botStoreLanguage"),
     globalAvailableModels: app.node.tryGetContext("globalAvailableModels"),
     defaultModel: app.node.tryGetContext("defaultModel"),
+    titleModel: app.node.tryGetContext("titleModel"),
     logoPath: app.node.tryGetContext("logoPath"),
     devAccessIamRoleArn: app.node.tryGetContext("devAccessIamRoleArn"),
   };

--- a/frontend/src/@types/global-config.d.ts
+++ b/frontend/src/@types/global-config.d.ts
@@ -2,6 +2,7 @@ import { AVAILABLE_MODEL_KEYS } from '../constants/index';
 
 export interface GlobalConfig {
   globalAvailableModels: string[];
+  defaultModel?: string;
   logoPath?: string;
 }
 

--- a/frontend/src/components/SwitchBedrockModel.tsx
+++ b/frontend/src/components/SwitchBedrockModel.tsx
@@ -2,7 +2,7 @@ import { BaseProps } from '../@types/common';
 import useModel from '../hooks/useModel';
 import { Popover, Transition } from '@headlessui/react';
 import { Fragment } from 'react/jsx-runtime';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { PiCaretDown, PiCheck } from 'react-icons/pi';
 import { ActiveModels } from '../@types/bot';
 import { toCamelCase } from '../utils/StringUtils';
@@ -17,6 +17,7 @@ const SwitchBedrockModel: React.FC<Props> = (props) => {
     availableModels: allModels,
     modelId,
     setModelId,
+    getDefaultModel,
   } = useModel(props.botId, props.activeModels);
 
   const availableModels = useMemo(() => {
@@ -32,11 +33,30 @@ const SwitchBedrockModel: React.FC<Props> = (props) => {
     });
   }, [allModels, props.activeModels]);
 
-  const modelName = useMemo(() => {
-    return (
-      availableModels.find((model) => model.modelId === modelId)?.label ?? ''
+  // Automatically switch to the default model if the current model is not available
+  useEffect(() => {
+    const isCurrentModelAvailable = availableModels.some(
+      (model) => model.modelId === modelId
     );
-  }, [availableModels, modelId]);
+
+    if (!isCurrentModelAvailable && availableModels.length > 0) {
+      const defaultModelId = getDefaultModel();
+      if (defaultModelId) {
+        setModelId(defaultModelId);
+      }
+    }
+  }, [availableModels, modelId, setModelId, getDefaultModel]);
+
+  const modelName = useMemo(() => {
+    const foundModel = availableModels.find((model) => model.modelId === modelId);
+    if (foundModel) {
+      return foundModel.label;
+    }
+    // Fallback to the default model's label if the current model is not found
+    const defaultModelId = getDefaultModel();
+    const defaultModel = availableModels.find((model) => model.modelId === defaultModelId);
+    return defaultModel?.label ?? '';
+  }, [availableModels, modelId, getDefaultModel]);
 
   return (
     <div className="">

--- a/frontend/src/components/SwitchBedrockModel.tsx
+++ b/frontend/src/components/SwitchBedrockModel.tsx
@@ -41,7 +41,7 @@ const SwitchBedrockModel: React.FC<Props> = (props) => {
 
     if (!isCurrentModelAvailable && availableModels.length > 0) {
       const defaultModelId = getDefaultModel();
-      if (defaultModelId) {
+      if (defaultModelId && defaultModelId !== modelId) {
         setModelId(defaultModelId);
       }
     }
@@ -52,10 +52,13 @@ const SwitchBedrockModel: React.FC<Props> = (props) => {
     if (foundModel) {
       return foundModel.label;
     }
-    // Fallback to the default model's label if the current model is not found
+    // Only call getDefaultModel if current model is not found
     const defaultModelId = getDefaultModel();
-    const defaultModel = availableModels.find((model) => model.modelId === defaultModelId);
-    return defaultModel?.label ?? '';
+    if (defaultModelId) {
+      const defaultModel = availableModels.find((model) => model.modelId === defaultModelId);
+      return defaultModel?.label ?? '';
+    }
+    return '';
   }, [availableModels, modelId, getDefaultModel]);
 
   return (

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -303,7 +303,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
     }
   }, [processedActiveModels, availableModels]);
 
-  const getDefaultModel = useCallback((): Model | undefined => {
+  const getDefaultModel = useCallback((): Model => {
     // Use the default model from global config if available
     const configDefaultModel = globalConfig?.defaultModel as Model | undefined;
 
@@ -319,7 +319,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
 
     // If config default is not available or not set yet, select the first model
     // Returns undefined if no models are available
-    return filteredModels[0]?.modelId;
+    return filteredModels[0]?.modelId ?? 'amazon-nova-lite';
   }, [filteredModels, globalConfig?.defaultModel]);
 
   // select the model via list of activeModels
@@ -328,7 +328,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
       const modelExists = filteredModels.some(
         (m: ModelItem) => toCamelCase(m.modelId) === toCamelCase(targetModelId)
       );
-      return modelExists ? targetModelId : getDefaultModel();
+      return modelExists ? targetModelId : (getDefaultModel() ?? filteredModels[0]?.modelId ?? 'amazon-nova-lite');
     },
     [filteredModels, getDefaultModel]
   );

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -31,10 +31,10 @@ const LLAMA_SUPPORTED_MEDIA_TYPES = [
 ];
 
 const useModelState = create<{
-  modelId: Model;
+  modelId: Model | undefined;
   setModelId: (m: Model) => void;
 }>((set) => ({
-  modelId: '' as Model, // Will be set by useEffect based on config/localStorage
+  modelId: undefined, // Will be set by useEffect based on config/localStorage
   setModelId: (m) => {
     set({
       modelId: m,
@@ -303,7 +303,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
     }
   }, [processedActiveModels, availableModels]);
 
-  const getDefaultModel = useCallback(() => {
+  const getDefaultModel = useCallback((): Model | undefined => {
     // Use the default model from global config if available
     const configDefaultModel = globalConfig?.defaultModel as Model | undefined;
 
@@ -318,6 +318,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
     }
 
     // If config default is not available or not set yet, select the first model
+    // Returns undefined if no models are available
     return filteredModels[0]?.modelId;
   }, [filteredModels, globalConfig?.defaultModel]);
 
@@ -386,13 +387,14 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   }, [botId]);
 
   const model = useMemo(() => {
+    if (!modelId) return undefined;
     return filteredModels.find(
       (model: ModelItem) => toCamelCase(model.modelId) === toCamelCase(modelId)
     );
   }, [filteredModels, modelId]);
 
   return {
-    modelId,
+    modelId: modelId ?? getDefaultModel(),
     setModelId: (model: Model) => {
       setRecentUseModelId(model);
       if (botId) {

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -387,7 +387,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   }, [botId]);
 
   const model = useMemo(() => {
-    if (!modelId) return undefined;
+    if (!modelId) { return undefined; }
     return filteredModels.find(
       (model: ModelItem) => toCamelCase(model.modelId) === toCamelCase(modelId)
     );

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -30,13 +30,11 @@ const LLAMA_SUPPORTED_MEDIA_TYPES = [
   'image/webp',
 ];
 
-const DEFAULT_MODEL: Model = 'claude-v3.7-sonnet';
-
 const useModelState = create<{
   modelId: Model;
   setModelId: (m: Model) => void;
 }>((set) => ({
-  modelId: DEFAULT_MODEL,
+  modelId: '' as Model, // Will be set by useEffect based on config/localStorage
   setModelId: (m) => {
     set({
       modelId: m,
@@ -285,7 +283,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   const { modelId, setModelId } = useModelState();
   const [recentUseModelId, setRecentUseModelId] = useLocalStorage(
     'recentUseModelId',
-    DEFAULT_MODEL
+    '' // Will use getDefaultModel() if localStorage is empty
   );
 
   // Save the model id by each bot
@@ -306,16 +304,22 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
   }, [processedActiveModels, availableModels]);
 
   const getDefaultModel = useCallback(() => {
-    // check default model is available
-    const defaultModelAvailable = filteredModels.some(
-      (m: ModelItem) => m.modelId === DEFAULT_MODEL
-    );
-    if (defaultModelAvailable) {
-      return DEFAULT_MODEL;
+    // Use the default model from global config if available
+    const configDefaultModel = globalConfig?.defaultModel as Model | undefined;
+
+    if (configDefaultModel) {
+      // Check if the configured default model is available
+      const defaultModelAvailable = filteredModels.some(
+        (m: ModelItem) => m.modelId === configDefaultModel
+      );
+      if (defaultModelAvailable) {
+        return configDefaultModel;
+      }
     }
-    // If the default model is not available, select the first model on the list
-    return filteredModels[0]?.modelId ?? DEFAULT_MODEL;
-  }, [filteredModels]);
+
+    // If config default is not available or not set yet, select the first model
+    return filteredModels[0]?.modelId;
+  }, [filteredModels, globalConfig?.defaultModel]);
 
   // select the model via list of activeModels
   const selectModel = useCallback(

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -409,6 +409,7 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
       }) ?? [],
     availableModels: filteredModels,
     forceReasoningEnabled: model?.forceReasoningEnabled ?? false,
+    getDefaultModel,
   };
 };
 


### PR DESCRIPTION
Before this change some model names were hardcoded in the codebase - _claude-v3-haiku_ for generating the convo titles and _claude-v3.7-sonnet_ as the default for everything else. The problem is that some accounts may not have access to these models and changing them is not trivial for the end users.

This PR adds a new config option `defaultModel` for setting this default model in cdk.json / parameter.ts so that the default model can be easily updated, perhaps along with `globalAvailableModels`.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
