### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  issues: write
+
 jobs:
   add-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,9 @@ on:
       - v3
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   black-mypy-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdk.yml
+++ b/.github/workflows/cdk.yml
@@ -8,6 +8,9 @@ on:
       - v3
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   cdk-synth:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-redoc.yml
+++ b/.github/workflows/deploy-redoc.yml
@@ -6,6 +6,10 @@ on:
       - main
       - v1
       - v3
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,9 @@ on:
       - v3
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-closure.yml
+++ b/.github/workflows/issue-closure.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 0 1 * * *
 
+permissions:
+  issues: write
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-contributor-highlights.yml
+++ b/.github/workflows/update-contributor-highlights.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 1 * *" # Every Month'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-highlights:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.