### PR TITLE
Change default `stop_sequences` setting to empty list

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,7 +27,7 @@ DEFAULT_GENERATION_CONFIG: GenerationParams = {
     "top_k": 250,
     "top_p": 0.999,
     "temperature": 1.0,
-    "stop_sequences": ["Human: ", "Assistant: "],
+    "stop_sequences": [],
     # Budget tokens must NOT exceeds max_tokens
     "reasoning_params": {"budget_tokens": 1024},
 }

--- a/frontend/src/components/InputChatContent.tsx
+++ b/frontend/src/components/InputChatContent.tsx
@@ -481,7 +481,7 @@ const InputChatContent = forwardRef<HTMLElement, Props>(
               key={`textarea-${props.isNewChat}`} // Add a key to force re-render
               className="m-1 bg-transparent pr-12 scrollbar-thin scrollbar-thumb-light-gray"
               placeholder={t('app.inputMessage')}
-              disabled={props.disabledSend || props.disabled}
+              disabled={props.disabled}
               noBorder
               rows={props.isNewChat ? 3 : 1}
               value={content}

--- a/frontend/src/components/InputChatContent.tsx
+++ b/frontend/src/components/InputChatContent.tsx
@@ -481,7 +481,7 @@ const InputChatContent = forwardRef<HTMLElement, Props>(
               key={`textarea-${props.isNewChat}`} // Add a key to force re-render
               className="m-1 bg-transparent pr-12 scrollbar-thin scrollbar-thumb-light-gray"
               placeholder={t('app.inputMessage')}
-              disabled={props.disabled}
+              disabled={props.disabledSend || props.disabled}
               noBorder
               rows={props.isNewChat ? 3 : 1}
               value={content}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -157,6 +157,15 @@ const ChatPage: React.FC = () => {
     }
   }, [bot]);
 
+  const isLastAssistantMessageEmpty = useMemo(() => {
+    if (messages.length === 0) {
+      return false;
+    }
+
+    const lastMessage = messages[messages.length - 1];
+    return lastMessage.role === 'assistant' && lastMessage.content.length === 0;
+  }, [messages]);
+
   const disabledInput = useMemo(() => {
     return botId !== null && !isAvailabilityBot && !isLoadingBot;
   }, [botId, isAvailabilityBot, isLoadingBot]);
@@ -676,7 +685,7 @@ const ChatPage: React.FC = () => {
         <InputChatContent
           className="mb-7 w-11/12 md:w-10/12 lg:w-4/6 xl:w-3/6"
           dndMode={dndMode}
-          disabledSend={postingMessage || hasError}
+          disabledSend={postingMessage || hasError || isLastAssistantMessageEmpty}
           disabledRegenerate={postingMessage || hasError}
           disabledContinue={postingMessage || hasError}
           disabled={disabledInput}


### PR DESCRIPTION
*Issue #, if available:*
Closes #972 

*Description of changes:*
- Change default stop_sequences setting to empty list.
- Allow only 'Regenere' after an empty assistant message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
