### PR TITLE
fix claude 4.1 opus error

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -392,6 +392,7 @@ def is_tooluse_supported(model: type_model_name) -> bool:
 
 def is_specify_both_temperature_and_top_p_supported(model: type_model_name) -> bool:
     return model not in [
+        "claude-v4.1-opus",
         "claude-v4.5-sonnet",
         "claude-v4.5-haiku",
     ]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR fixes problem with Anthropic Claude 4.1 Opus "temperature and top_p` cannot both be specified for this model." error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
