### PR TITLE
Add claude 4.5 opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ npm ci
   - `logoPath`: Relative path under `frontend/public` that points to the image displayed at the top of the application drawer.
     The following model IDs are supported (please make sure that they are also enabled in the Bedrock console under Model access in your deployment region):
 
-- **Claude Models:** `claude-v4-opus`, `claude-v4.1-opus`, `claude-v4-sonnet`, `claude-v3.5-sonnet`, `claude-v3.5-sonnet-v2`, `claude-v3.7-sonnet`, `claude-v3.5-haiku`, `claude-v3-haiku`, `claude-v3-opus`
+- **Claude Models:** `claude-v4-opus`, `claude-v4.1-opus`, `claude-v4.5-opus`, `claude-v4-sonnet`, `claude-v3.5-sonnet`, `claude-v3.5-sonnet-v2`, `claude-v3.7-sonnet`, `claude-v3.5-haiku`, `claude-v3-haiku`, `claude-v3-opus`
 - **Amazon Nova Models:** `amazon-nova-pro`, `amazon-nova-lite`, `amazon-nova-micro`
 - **Mistral Models:** `mistral-7b-instruct`, `mixtral-8x7b-instruct`, `mistral-large`, `mistral-large-2`
 - **DeepSeek Models:** `deepseek-r1`

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -59,6 +59,7 @@ ENABLE_BEDROCK_CROSS_REGION_INFERENCE = (
 BASE_MODEL_IDS = {
     "claude-v4-opus": "anthropic.claude-opus-4-20250514-v1:0",
     "claude-v4.1-opus": "anthropic.claude-opus-4-1-20250805-v1:0",
+    "claude-v4.5-opus": "anthropic.claude-opus-4-5-20251101-v1:0",
     "claude-v4-sonnet": "anthropic.claude-sonnet-4-20250514-v1:0",
     "claude-v4.5-sonnet": "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "claude-v4.5-haiku": "anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -88,6 +89,33 @@ BASE_MODEL_IDS = {
 
 # Global inference profiles
 GLOBAL_INFERENCE_PROFILES = {
+    "claude-v4.5-opus": {
+        "supported_regions": [
+            "us-west-2",
+            "us-west-1",
+            "us-east-2",
+            "us-east-1",
+            "sa-east-1",
+            "eu-west-3",
+            "eu-west-2",
+            "eu-west-1",
+            "eu-south-2",
+            "eu-south-1",
+            "eu-north-1",
+            "eu-central-2",
+            "eu-central-1",
+            "ca-central-1",
+            "ap-southeast-4",
+            "ap-southeast-3",
+            "ap-southeast-2",
+            "ap-southeast-1",
+            "ap-south-2",
+            "ap-south-1",
+            "ap-northeast-3",
+            "ap-northeast-2",
+            "ap-northeast-1",
+        ]
+    },
     "claude-v4-sonnet": {
         "supported_regions": [
             "us-west-2",
@@ -161,6 +189,7 @@ REGIONAL_INFERENCE_PROFILES = {
     "claude-v4.1-opus": {
         "supported_regions": {"us-east-1": "us", "us-east-2": "us", "us-west-2": "us"}
     },
+    # "claude-v4.5-opus" only available on global endpoint
     "claude-v4-sonnet": {
         "supported_regions": {
             "us-east-1": "us",
@@ -393,6 +422,7 @@ def is_tooluse_supported(model: type_model_name) -> bool:
 def is_specify_both_temperature_and_top_p_supported(model: type_model_name) -> bool:
     return model not in [
         "claude-v4.1-opus",
+        "claude-v4.5-opus",
         "claude-v4.5-sonnet",
         "claude-v4.5-haiku",
     ]
@@ -405,6 +435,7 @@ def is_prompt_caching_supported(
         return model in [
             "claude-v4-opus",
             "claude-v4.1-opus",
+            "claude-v4.5-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
             "claude-v4.5-haiku",
@@ -417,6 +448,7 @@ def is_prompt_caching_supported(
         return model in [
             "claude-v4-opus",
             "claude-v4.1-opus",
+            "claude-v4.5-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
             "claude-v4.5-haiku",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -232,6 +232,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.01875,
             "cache_read_input": 0.0015,
         },
+        "claude-v4.5-opus": {
+            "input": 0.005,
+            "output": 0.025,
+            "cache_write_input": 0.00625,
+            "cache_read_input": 0.0005,
+        },
         "claude-v4-sonnet": {
             "input": 0.003,
             "output": 0.015,

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -8,6 +8,7 @@ from pydantic import Discriminator, Field, JsonValue, root_validator
 type_model_name = Literal[
     "claude-v4-opus",
     "claude-v4.1-opus",
+    "claude-v4.5-opus",
     "claude-v4-sonnet",
     "claude-v4.5-sonnet",
     "claude-v4.5-haiku",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -84,6 +84,7 @@ export const GUARDRAILS_CONTEXTUAL_GROUNDING_THRESHOLD = {
 export const AVAILABLE_MODEL_KEYS = [
   'claude-v4-opus',
   'claude-v4.1-opus',
+  'claude-v4.5-opus',
   'claude-v4-sonnet',
   'claude-v4.5-sonnet',
   'claude-v4.5-haiku',

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -93,6 +93,13 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportReasoning: true,
       },
       {
+        modelId: 'claude-v4.5-opus',
+        label: t('model.claude-v4.5-opus.label'),
+        description: t('model.claude-v4.5-opus.description'),
+        supportMediaType: CLAUDE_SUPPORTED_MEDIA_TYPES,
+        supportReasoning: true,
+      },
+      {
         modelId: 'claude-v4-sonnet',
         label: t('model.claude-v4-sonnet.label'),
         description: t('model.claude-v4-sonnet.description'),

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -30,6 +30,11 @@ const translation = {
         description:
           'Latest version of the most powerful Opus model with enhanced reasoning capabilities.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'The most intelligent model combining maximum capability with practical performance. Features a more accessible price point than previous Opus models.',
+      },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',
         description:

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -41,6 +41,11 @@ const translation = {
         description:
           'La versión más reciente del modelo Claude más potente con capacidades de razonamiento mejoradas.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'Nuestro modelo más inteligente que combina capacidad máxima con rendimiento práctico.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo potente para tareas altamente complejas.',

--- a/frontend/src/i18n/id/index.ts
+++ b/frontend/src/i18n/id/index.ts
@@ -41,6 +41,11 @@ const translation = {
         description:
           'Versi terbaru dari model Claude terkuat dengan kemampuan penalaran yang ditingkatkan.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'Model paling cerdas kami yang menggabungkan kemampuan maksimal dengan kinerja praktis.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Model yang kuat untuk tugas-tugas yang sangat kompleks.',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -33,6 +33,11 @@ const translation: typeof en = {
         description:
           '最も強力なOpusの最新版。推論能力が向上',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          '最大の能力と実用的なパフォーマンスを組み合わせた最も知的なモデル。',
+      },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',
         description:

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -41,6 +41,11 @@ const translation = {
         description:
           'Najnowsza wersja najsilniejszego modelu Claude z ulepszonymi możliwościami rozumowania.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'Nasz najinteligentniejszy model łączący maksymalną funkcjonalność z praktyczną wydajnością.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Potężny model do wysoce złożonych zadań.',

--- a/frontend/src/i18n/pt-br/index.ts
+++ b/frontend/src/i18n/pt-br/index.ts
@@ -48,6 +48,11 @@ const translation = {
         description:
           'A versão mais recente do modelo Claude mais poderoso com capacidades de raciocínio aprimoradas.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'Nosso modelo mais inteligente, combinando capacidade máxima com desempenho prático.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo poderoso para tarefas altamente complexas.',

--- a/frontend/src/i18n/vi/index.ts
+++ b/frontend/src/i18n/vi/index.ts
@@ -41,6 +41,11 @@ const translation = {
         description:
           'Phiên bản mới nhất của mô hình Claude mạnh nhất với khả năng lý luận được cải thiện.',
       },
+      'claude-v4.5-opus': {
+        label: 'Claude 4.5 (Opus)',
+        description:
+          'The most intelligent model combining maximum capability with practical performance. Features a more accessible price point than previous Opus models.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Mô hình mạnh mẽ cho các tác vụ cực kỳ phức tạp.',


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/bedrock-chat/issues/980

*Description of changes:*
Add Claude 4.5 Opus model.

It worked with:
- app region: ap-northeast-1
- bedrock region: us-east-1
- `enableBedrockGlobalInference`: true
- `enableBedrockCrossRegionInference`: true

~~It seems to send `<budget:budget_strategy>` region like thinking-region.
I'm not sure whether app should handle them or strand agent/client library should.~~
Retryed and it worked fine.

<img width="1651" height="966" alt="chatbot" src="https://github.com/user-attachments/assets/fbd44a8c-3c12-4aaf-a718-6e4c62187ecc" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
