### PR TITLE
Select existing KB from a drop-down

### DIFF
--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from app.utils import get_bedrock_agent_client
 from app.repositories.models.custom_bot_kb import (
@@ -6,6 +7,7 @@ from app.repositories.models.custom_bot_kb import (
     KnowledgeBase,
     KnowledgeBaseConfiguration,
 )
+from app.routes.schemas.knowledge_base import KnowledgeBaseListItem
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -33,3 +35,31 @@ def get_knowledge_base_info(
                 knowledge_base_configuration=KnowledgeBaseConfiguration(type="VECTOR")
             )
         )
+
+
+def list_knowledge_bases() -> List[KnowledgeBaseListItem]:
+    """List all available knowledge bases in the account."""
+    client = get_bedrock_agent_client()
+    knowledge_bases: List[KnowledgeBaseListItem] = []
+
+    try:
+        paginator = client.get_paginator("list_knowledge_bases")
+        page_iterator = paginator.paginate()
+
+        for page in page_iterator:
+            for kb in page.get("knowledgeBaseSummaries", []):
+                knowledge_bases.append(
+                    KnowledgeBaseListItem(
+                        knowledge_base_id=kb.get("knowledgeBaseId", ""),
+                        name=kb.get("name", ""),
+                        description=kb.get("description"),
+                        status=kb.get("status", "UNKNOWN"),
+                    )
+                )
+
+        logger.info(f"Found {len(knowledge_bases)} knowledge bases")
+        return knowledge_bases
+
+    except Exception as e:
+        logger.error(f"Failed to list knowledge bases: {e}")
+        return []

--- a/backend/app/repositories/knowledge_base.py
+++ b/backend/app/repositories/knowledge_base.py
@@ -48,11 +48,14 @@ def list_knowledge_bases() -> List[KnowledgeBaseListItem]:
 
         for page in page_iterator:
             for kb in page.get("knowledgeBaseSummaries", []):
+                kb_id = kb.get("knowledgeBaseId")
+                kb_name = kb.get("name", kb_id)  # Fallback to ID if name is missing
+                logger.debug(f"Found knowledge base: ID={kb_id}, Name={kb_name}")
                 knowledge_bases.append(
                     KnowledgeBaseListItem(
-                        knowledge_base_id=kb.get("knowledgeBaseId", ""),
-                        name=kb.get("name", ""),
-                        description=kb.get("description"),
+                        knowledge_base_id=kb_id,
+                        name=kb_name,
+                        description=kb.get("description", ""),
                         status=kb.get("status", "UNKNOWN"),
                     )
                 )

--- a/backend/app/routes/bot.py
+++ b/backend/app/routes/bot.py
@@ -170,7 +170,7 @@ def get_bot_available_tools(request: Request, bot_id: str):
 
 
 @router.get("/knowledge-bases", response_model=ListKnowledgeBasesResponse)
-def get_knowledge_bases(request: Request):
+def get_knowledge_bases():
     """List all available knowledge bases in the account."""
     knowledge_bases = list_knowledge_bases()
     return ListKnowledgeBasesResponse(knowledge_bases=knowledge_bases)

--- a/backend/app/routes/bot.py
+++ b/backend/app/routes/bot.py
@@ -172,6 +172,5 @@ def get_bot_available_tools(request: Request, bot_id: str):
 @router.get("/knowledge-bases", response_model=ListKnowledgeBasesResponse)
 def get_knowledge_bases(request: Request):
     """List all available knowledge bases in the account."""
-    current_user: User = request.state.current_user
     knowledge_bases = list_knowledge_bases()
     return ListKnowledgeBasesResponse(knowledge_bases=knowledge_bases)

--- a/backend/app/routes/bot.py
+++ b/backend/app/routes/bot.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Literal
 
 from app.dependencies import check_creating_bot_allowed
 from app.repositories.custom_bot import find_bot_by_id
+from app.repositories.knowledge_base import list_knowledge_bases
 from app.routes.schemas.bot import (
     BotInput,
     BotMetaOutput,
@@ -14,6 +15,7 @@ from app.routes.schemas.bot import (
     BotSwitchVisibilityInput,
     Tool,
 )
+from app.routes.schemas.knowledge_base import ListKnowledgeBasesResponse
 from app.routes.schemas.conversation import type_model_name
 from app.usecases.bot import (
     create_new_bot,
@@ -165,3 +167,11 @@ def get_bot_available_tools(request: Request, bot_id: str):
     """Get available tools for bot"""
     tools = fetch_available_agent_tools()
     return tools
+
+
+@router.get("/knowledge-bases", response_model=ListKnowledgeBasesResponse)
+def get_knowledge_bases(request: Request):
+    """List all available knowledge bases in the account."""
+    current_user: User = request.state.current_user
+    knowledge_bases = list_knowledge_bases()
+    return ListKnowledgeBasesResponse(knowledge_bases=knowledge_bases)

--- a/backend/app/routes/schemas/knowledge_base.py
+++ b/backend/app/routes/schemas/knowledge_base.py
@@ -1,0 +1,16 @@
+from app.routes.schemas.base import BaseSchema
+
+
+class KnowledgeBaseListItem(BaseSchema):
+    """Knowledge Base list item for dropdown selection."""
+
+    knowledge_base_id: str
+    name: str
+    description: str | None = None
+    status: str
+
+
+class ListKnowledgeBasesResponse(BaseSchema):
+    """Response containing list of available knowledge bases."""
+
+    knowledge_bases: list[KnowledgeBaseListItem]

--- a/backend/tests/test_repositories/test_knowledge_base.py
+++ b/backend/tests/test_repositories/test_knowledge_base.py
@@ -219,9 +219,7 @@ class TestKnowledgeBaseRepository(unittest.TestCase):
 
     @patch("app.repositories.knowledge_base.logger")
     @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
-    def test_list_knowledge_bases_logging_success(
-        self, mock_get_client, mock_logger
-    ):
+    def test_list_knowledge_bases_logging_success(self, mock_get_client, mock_logger):
         """Test that successful execution logs the count"""
         # Setup mock client and paginator
         mock_client = MagicMock()
@@ -306,6 +304,7 @@ class TestKnowledgeBaseRepository(unittest.TestCase):
         self.assertEqual(kb.name, test_name)
         self.assertEqual(kb.description, test_desc)
         self.assertEqual(kb.status, test_status)
+
 
 # (Remove lines 310-342 entirely)
 if __name__ == "__main__":

--- a/backend/tests/test_repositories/test_knowledge_base.py
+++ b/backend/tests/test_repositories/test_knowledge_base.py
@@ -1,0 +1,345 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, ".")
+
+from app.repositories.knowledge_base import list_knowledge_bases
+from app.routes.schemas.knowledge_base import KnowledgeBaseListItem
+
+
+class TestKnowledgeBaseRepository(unittest.TestCase):
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_success_single_page(self, mock_get_client):
+        """Test successful listing of knowledge bases with single page of results"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock single page response
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB123",
+                        "name": "Test KB 1",
+                        "description": "First test knowledge base",
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "knowledgeBaseId": "KB456",
+                        "name": "Test KB 2",
+                        "description": "Second test knowledge base",
+                        "status": "CREATING",
+                    },
+                ]
+            }
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], KnowledgeBaseListItem)
+        self.assertEqual(result[0].knowledge_base_id, "KB123")
+        self.assertEqual(result[0].name, "Test KB 1")
+        self.assertEqual(result[0].description, "First test knowledge base")
+        self.assertEqual(result[0].status, "ACTIVE")
+        self.assertEqual(result[1].knowledge_base_id, "KB456")
+        self.assertEqual(result[1].name, "Test KB 2")
+        self.assertEqual(result[1].status, "CREATING")
+
+        # Verify client was called correctly
+        mock_client.get_paginator.assert_called_once_with("list_knowledge_bases")
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_success_multiple_pages(self, mock_get_client):
+        """Test successful listing with pagination across multiple pages"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock multiple pages
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB001",
+                        "name": "KB Page 1 - Item 1",
+                        "description": "Description 1",
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "knowledgeBaseId": "KB002",
+                        "name": "KB Page 1 - Item 2",
+                        "description": "Description 2",
+                        "status": "ACTIVE",
+                    },
+                ]
+            },
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB003",
+                        "name": "KB Page 2 - Item 1",
+                        "description": "Description 3",
+                        "status": "UPDATING",
+                    },
+                ]
+            },
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB004",
+                        "name": "KB Page 3 - Item 1",
+                        "description": "Description 4",
+                        "status": "DELETING",
+                    },
+                    {
+                        "knowledgeBaseId": "KB005",
+                        "name": "KB Page 3 - Item 2",
+                        "description": "Description 5",
+                        "status": "ACTIVE",
+                    },
+                ]
+            },
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert - should aggregate all pages
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0].knowledge_base_id, "KB001")
+        self.assertEqual(result[2].knowledge_base_id, "KB003")
+        self.assertEqual(result[4].knowledge_base_id, "KB005")
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_empty_results(self, mock_get_client):
+        """Test handling of empty results"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock empty response
+        mock_paginator.paginate.return_value = [{"knowledgeBaseSummaries": []}]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert
+        self.assertEqual(len(result), 0)
+        self.assertIsInstance(result, list)
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_missing_optional_fields(self, mock_get_client):
+        """Test handling of KB entries with missing optional fields"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock response with missing optional fields
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB789",
+                        "name": "Minimal KB",
+                        # No description
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "knowledgeBaseId": "KB000",
+                        "name": "KB without status",
+                        "description": "Has description but no status",
+                        # No status - should default to "UNKNOWN"
+                    },
+                ]
+            }
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].knowledge_base_id, "KB789")
+        self.assertEqual(result[0].name, "Minimal KB")
+        self.assertIsNone(result[0].description)
+        self.assertEqual(result[0].status, "ACTIVE")
+
+        self.assertEqual(result[1].knowledge_base_id, "KB000")
+        self.assertEqual(result[1].description, "Has description but no status")
+        self.assertEqual(result[1].status, "UNKNOWN")
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_api_error(self, mock_get_client):
+        """Test error handling when Bedrock API call fails"""
+        # Setup mock client to raise an exception
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.side_effect = Exception(
+            "Bedrock API connection failed"
+        )
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert - should return empty list on error
+        self.assertEqual(result, [])
+        self.assertIsInstance(result, list)
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_pagination_error(self, mock_get_client):
+        """Test error handling when pagination fails mid-iteration"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock paginator that raises exception during iteration
+        mock_paginator.paginate.side_effect = Exception("Pagination failed")
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert - should return empty list on error
+        self.assertEqual(result, [])
+        self.assertIsInstance(result, list)
+
+    @patch("app.repositories.knowledge_base.logger")
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_logging_success(
+        self, mock_get_client, mock_logger
+    ):
+        """Test that successful execution logs the count"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "KB1",
+                        "name": "Test",
+                        "status": "ACTIVE",
+                    }
+                ]
+            }
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert logging
+        mock_logger.info.assert_called_once_with("Found 1 knowledge bases")
+        self.assertEqual(len(result), 1)
+
+    @patch("app.repositories.knowledge_base.logger")
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_logging_error(self, mock_get_client, mock_logger):
+        """Test that errors are logged properly"""
+        # Setup mock client to raise exception
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        error_message = "Test API error"
+        mock_client.get_paginator.side_effect = Exception(error_message)
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert logging and return value
+        self.assertEqual(result, [])
+        mock_logger.error.assert_called_once()
+        # Check that the error message contains our exception
+        call_args = mock_logger.error.call_args[0][0]
+        self.assertIn("Failed to list knowledge bases", call_args)
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_field_mapping(self, mock_get_client):
+        """Test correct mapping of API response fields to schema"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock response with all fields
+        test_id = "TEST-KB-12345"
+        test_name = "Production Knowledge Base"
+        test_desc = "Contains production documentation and FAQs"
+        test_status = "ACTIVE"
+
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": test_id,
+                        "name": test_name,
+                        "description": test_desc,
+                        "status": test_status,
+                    }
+                ]
+            }
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert field mapping
+        self.assertEqual(len(result), 1)
+        kb = result[0]
+        self.assertEqual(kb.knowledge_base_id, test_id)
+        self.assertEqual(kb.name, test_name)
+        self.assertEqual(kb.description, test_desc)
+        self.assertEqual(kb.status, test_status)
+
+    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
+    def test_list_knowledge_bases_empty_strings(self, mock_get_client):
+        """Test handling of empty string values in API response"""
+        # Setup mock client and paginator
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+
+        # Mock response with empty strings
+        mock_paginator.paginate.return_value = [
+            {
+                "knowledgeBaseSummaries": [
+                    {
+                        "knowledgeBaseId": "",
+                        "name": "",
+                        "description": "",
+                        "status": "",
+                    }
+                ]
+            }
+        ]
+
+        # Execute
+        result = list_knowledge_bases()
+
+        # Assert - empty strings should be preserved (not converted to None)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].knowledge_base_id, "")
+        self.assertEqual(result[0].name, "")
+        self.assertEqual(result[0].description, "")
+        self.assertEqual(result[0].status, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_repositories/test_knowledge_base.py
+++ b/backend/tests/test_repositories/test_knowledge_base.py
@@ -307,39 +307,6 @@ class TestKnowledgeBaseRepository(unittest.TestCase):
         self.assertEqual(kb.description, test_desc)
         self.assertEqual(kb.status, test_status)
 
-    @patch("app.repositories.knowledge_base.get_bedrock_agent_client")
-    def test_list_knowledge_bases_empty_strings(self, mock_get_client):
-        """Test handling of empty string values in API response"""
-        # Setup mock client and paginator
-        mock_client = MagicMock()
-        mock_paginator = MagicMock()
-        mock_get_client.return_value = mock_client
-        mock_client.get_paginator.return_value = mock_paginator
-
-        # Mock response with empty strings
-        mock_paginator.paginate.return_value = [
-            {
-                "knowledgeBaseSummaries": [
-                    {
-                        "knowledgeBaseId": "",
-                        "name": "",
-                        "description": "",
-                        "status": "",
-                    }
-                ]
-            }
-        ]
-
-        # Execute
-        result = list_knowledge_bases()
-
-        # Assert - empty strings should be preserved (not converted to None)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].knowledge_base_id, "")
-        self.assertEqual(result[0].name, "")
-        self.assertEqual(result[0].description, "")
-        self.assertEqual(result[0].status, "")
-
-
+# (Remove lines 310-342 entirely)
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/@types/knowledgeBase.d.ts
+++ b/frontend/src/@types/knowledgeBase.d.ts
@@ -1,0 +1,10 @@
+export type KnowledgeBaseListItem = {
+  knowledgeBaseId: string;
+  name: string;
+  description: string | null;
+  status: string;
+};
+
+export type ListKnowledgeBasesResponse = {
+  knowledgeBases: KnowledgeBaseListItem[];
+};

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -84,7 +84,11 @@ const BotKbEditPage: React.FC = () => {
   const { getGlobalConfig } = useGlobalConfig();
   const { data: globalConfig } = getGlobalConfig();
   const { listKnowledgeBases } = useKnowledgeBaseApi();
-  const { data: knowledgeBasesData } = listKnowledgeBases();
+  const {
+    data: knowledgeBasesData,
+    isLoading: isLoadingKnowledgeBases,
+    error: knowledgeBasesError,
+  } = listKnowledgeBases();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -1631,6 +1635,7 @@ const BotKbEditPage: React.FC = () => {
                     label={t(
                       'knowledgeBaseSettings.advancedConfigration.useExistingKnowledgeBase.label'
                     )}
+                    disabled={!!knowledgeBasesError}
                     onChange={() => setKnowledgeBaseType('existing')}
                   />
                 </div>
@@ -1655,15 +1660,31 @@ const BotKbEditPage: React.FC = () => {
                           value={existKnowledgeBaseId ?? ''}
                           options={knowledgeBaseOptions}
                           onChange={setExistKnowledgeBaseId}
-                          disabled={knowledgeBaseOptions.length === 0}
+                          disabled={
+                            isLoadingKnowledgeBases ||
+                            !!knowledgeBasesError ||
+                            knowledgeBaseOptions.length === 0
+                          }
                         />
-                        {knowledgeBaseOptions.length === 0 && (
-                          <div className="mt-2 text-sm text-red">
-                            {t(
-                              'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.noKnowledgeBasesFound'
-                            )}
+                        {isLoadingKnowledgeBases && (
+                          <div className="mt-2 text-sm text-aws-font-color-light dark:text-aws-font-color-dark">
+                            {t('bot.label.loadingKnowledgeBases')}
                           </div>
                         )}
+                        {knowledgeBasesError && (
+                          <div className="mt-2 text-sm text-red">
+                            {t('bot.label.failedToLoadKnowledgeBases')}
+                          </div>
+                        )}
+                        {!isLoadingKnowledgeBases &&
+                          !knowledgeBasesError &&
+                          knowledgeBaseOptions.length === 0 && (
+                            <div className="mt-2 text-sm text-red">
+                              {t(
+                                'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.noKnowledgeBasesFound'
+                              )}
+                            </div>
+                          )}
                         <div className="mt-2 text-sm text-aws-font-color-light/50 dark:text-aws-font-color-dark">
                           {t(
                             'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.description'

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -1662,8 +1662,7 @@ const BotKbEditPage: React.FC = () => {
                           onChange={setExistKnowledgeBaseId}
                           disabled={
                             isLoadingKnowledgeBases ||
-                            !!knowledgeBasesError ||
-                            knowledgeBaseOptions.length === 0
+                            !!knowledgeBasesError
                           }
                         />
                         {isLoadingKnowledgeBases && (

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -69,6 +69,7 @@ import {
 } from '../types';
 import { toCamelCase } from '../../../utils/StringUtils';
 import useGlobalConfig from '../../../hooks/useGlobalConfig';
+import useKnowledgeBaseApi from '../../../hooks/useKnowledgeBaseApi';
 
 const edgeGenerationParams = EDGE_GENERATION_PARAMS;
 
@@ -82,6 +83,8 @@ const BotKbEditPage: React.FC = () => {
   const { availableTools } = useAgent();
   const { getGlobalConfig } = useGlobalConfig();
   const { data: globalConfig } = getGlobalConfig();
+  const { listKnowledgeBases } = useKnowledgeBaseApi();
+  const { data: knowledgeBasesData } = listKnowledgeBases();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -1604,7 +1607,10 @@ const BotKbEditPage: React.FC = () => {
                     label={t(
                       'knowledgeBaseSettings.advancedConfigration.createDedicatedKnowledgeBase.label'
                     )}
-                    onChange={() => setKnowledgeBaseType('new')}
+                    onChange={() => {
+                      setKnowledgeBaseType('new');
+                      setExistKnowledgeBaseId(null);
+                    }}
                   />
                   <RadioButton
                     name="knowledgeBaseType"
@@ -1613,7 +1619,10 @@ const BotKbEditPage: React.FC = () => {
                     label={t(
                       'knowledgeBaseSettings.advancedConfigration.createTenantInSharedKnowledgeBase.label'
                     )}
-                    onChange={() => setKnowledgeBaseType('shared')}
+                    onChange={() => {
+                      setKnowledgeBaseType('shared');
+                      setExistKnowledgeBaseId(null);
+                    }}
                   />
                   <RadioButton
                     name="knowledgeBaseType"
@@ -1628,18 +1637,34 @@ const BotKbEditPage: React.FC = () => {
 
                 {(() => {
                   if (knowledgeBaseType === 'existing') {
+                    // Prepare knowledge base options for the dropdown
+                    const knowledgeBaseOptions = (
+                      knowledgeBasesData?.knowledgeBases || []
+                    ).map((kb) => ({
+                      value: kb.knowledgeBaseId,
+                      label: `${kb.name} (${kb.knowledgeBaseId})`,
+                      description: kb.description || kb.status,
+                    }));
+
                     return (
                       <div className="mt-3 rounded-lg border border-aws-font-color-light/30 p-4 dark:border-aws-font-color-dark/30">
-                        <InputText
+                        <Select
                           label={t(
                             'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.label'
                           )}
                           value={existKnowledgeBaseId ?? ''}
+                          options={knowledgeBaseOptions}
                           onChange={setExistKnowledgeBaseId}
-                          disabled={!isNewBot}
-                          placeholder="ABCDEFGHIJ"
+                          disabled={knowledgeBaseOptions.length === 0}
                         />
-                        <div className="text-sm text-aws-font-color-light/50 dark:text-aws-font-color-dark">
+                        {knowledgeBaseOptions.length === 0 && (
+                          <div className="mt-2 text-sm text-red">
+                            {t(
+                              'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.noKnowledgeBasesFound'
+                            )}
+                          </div>
+                        )}
+                        <div className="mt-2 text-sm text-aws-font-color-light/50 dark:text-aws-font-color-dark">
                           {t(
                             'knowledgeBaseSettings.advancedConfigration.existingKnowledgeBaseId.description'
                           )}

--- a/frontend/src/hooks/useKnowledgeBaseApi.ts
+++ b/frontend/src/hooks/useKnowledgeBaseApi.ts
@@ -1,0 +1,14 @@
+import { ListKnowledgeBasesResponse } from '../@types/knowledgeBase';
+import useHttp from './useHttp';
+
+const useKnowledgeBaseApi = () => {
+  const http = useHttp();
+
+  return {
+    listKnowledgeBases: () => {
+      return http.get<ListKnowledgeBasesResponse>('knowledge-bases');
+    },
+  };
+};
+
+export default useKnowledgeBaseApi;

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -947,9 +947,11 @@ How would you categorize this email?`,
       },
       advancedConfigration: {
         existingKnowledgeBaseId: {
-          label: 'ID for the Amazon Bedrock Knowledge Base',
+          label: 'Amazon Bedrock Knowledge Base ID',
           description:
-            'Please specify ID that your existing Amazon Bedrock knowledge base.',
+            'Please specify the ID of your existing Amazon Bedrock knowledge base.',
+          noKnowledgeBasesFound:
+            'No knowledge bases found in your account. Please create a knowledge base first.',
         },
         createDedicatedKnowledgeBase: {
           label: 'Create a dedicated Knowledge Base',
@@ -958,7 +960,7 @@ How would you categorize this email?`,
           label: 'Create a tenant in a shared Knowledge Base',
         },
         useExistingKnowledgeBase: {
-          label: 'Use your existing Knowledge Base',
+          label: 'Use an existing Knowledge Base',
         },
       },
     },

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -952,7 +952,7 @@ How would you categorize this email?`,
         existingKnowledgeBaseId: {
           label: 'Amazon Bedrock Knowledge Base ID',
           description:
-            'Please specify the ID of your existing Amazon Bedrock knowledge base.',
+            'Select your existing Amazon Bedrock knowledge base.',
           noKnowledgeBasesFound:
             'No knowledge bases found in your account. Please create a knowledge base first.',
         },

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -276,6 +276,9 @@ const translation = {
         },
         citeRetrievedContexts: 'Retrieved Context Citation',
         unsupported: 'Unsupported, Read-only',
+        loadingKnowledgeBases: 'Loading knowledge bases...',
+        failedToLoadKnowledgeBases:
+          'Failed to load knowledge bases. Please try again later.',
       },
       titleSubmenu: {
         edit: 'Edit',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -277,6 +277,9 @@ const translation: typeof en = {
         },
         citeRetrievedContexts: '取得したコンテキストの引用',
         unsupported: '非対応、読み取り専用',
+        loadingKnowledgeBases: 'ナレッジベースを読み込み中...',
+        failedToLoadKnowledgeBases:
+          'ナレッジベースの読み込みに失敗しました。後でもう一度お試しください。',
       },
       titleSubmenu: {
         edit: 'ボットを編集',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -956,6 +956,8 @@ const translation: typeof en = {
           label: '既存のAmazon Bedrock Knowledge BaseのID',
           description:
             '既存のAmazon Bedrock Knowledge Baseを利用できます',
+          noKnowledgeBasesFound:
+            'アカウントにナレッジベースが見つかりません。最初にナレッジベースを作成してください。',
         },
         createDedicatedKnowledgeBase: {
           label: '専用のKnowledge Baseを作成する',


### PR DESCRIPTION
Replaces the text input for selecting existing Knowledge Base ID in a Bot creation page with a dropdown select that lists all available knowledge bases in the AWS account.

*Description of changes:*

Backend changes:
- Add list_knowledge_bases() function to repository layer using Bedrock Agent API pagination
- Add GET /knowledge-bases endpoint to bot routes

Frontend changes:
- Import useKnowledgeBaseApi hook to fetch available knowledge bases
- Replace InputText with Select component for KB selection
- Show error message when no knowledge bases are found
- Add i18n translations for 'no knowledge bases found' message (en/ja)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.