### PR TITLE
Fix: [BUG] Extra escaping character '\' in code samples #941

### DIFF
--- a/frontend/src/components/ChatMessageMarkdown.tsx
+++ b/frontend/src/components/ChatMessageMarkdown.tsx
@@ -117,16 +117,9 @@ const ChatMessageMarkdown: React.FC<Props> = ({
       },
     );
 
-    // Simple approach: only allow $$ for math, escape single $ that are not part of valid math
-    // This regex looks for $ that are not followed by another $ and not preceded by another $
-    // Examples:
-    // - "$5.99" becomes "\$5.99" (not processed as math)
-    // - "$x + y$" becomes "\$x + y\$" (not processed as math)
-    // - "$$x + y$$" stays "$$x + y$$" (processed as block math)
-    textReplacedSourceId = textReplacedSourceId.replace(
-      /(?<!\$)\$(?!\$)/g,
-      '\\$'
-    );
+    // Note: We no longer escape single $ here because remark-math is configured
+    // to only recognize $$ for display math (singleDollarTextMath: false)
+    // This prevents conflicts with code containing $ (like PHP variables, shell scripts, etc.)
 
     if (isStreaming) {
       textReplacedSourceId += chatWaitingSymbol;


### PR DESCRIPTION
*Issue #, if available:*
[941](https://github.com/aws-samples/bedrock-chat/issues/941)

*Description of changes:*

Frontend changes:

- Removed the single _$_ escape to prevent conflicts with code containing $ (PHP variables, shell, etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
