### PR TITLE
fix: pin Poetry to 1.8.5 in Dockerfiles and CDK bundling

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ COPY ./pyproject.toml ./poetry.lock ./
 
 ENV POETRY_REQUESTS_TIMEOUT=10800
 RUN python -m pip install --upgrade pip && \
-    pip install poetry --no-cache-dir && \
+    pip install "poetry==1.8.5" --no-cache-dir && \
     poetry config virtualenvs.create false && \
     poetry install --no-interaction --no-ansi --only main && \
     poetry cache clear --all pypi

--- a/backend/lambda.Dockerfile
+++ b/backend/lambda.Dockerfile
@@ -4,7 +4,7 @@ COPY ./pyproject.toml ./poetry.lock ./
 
 ENV POETRY_REQUESTS_TIMEOUT=10800
 RUN python -m pip install --upgrade pip && \
-    pip install poetry --no-cache-dir && \
+    pip install "poetry==1.8.5" --no-cache-dir && \
     poetry config virtualenvs.create false && \
     poetry install --no-interaction --no-ansi --only main && \
     poetry cache clear --all pypi

--- a/cdk/lib/constructs/api.ts
+++ b/cdk/lib/constructs/api.ts
@@ -243,7 +243,7 @@ export class Api extends Construct {
       index: "app/main.py",
       bundling: {
         assetExcludes: [...excludeDockerImage],
-        buildArgs: { POETRY_VERSION: "1.8.3" },
+        buildArgs: { POETRY_VERSION: "1.8.5" },
       },
       runtime: Runtime.PYTHON_3_13,
       architecture: Architecture.X86_64,

--- a/cdk/lib/constructs/websocket.ts
+++ b/cdk/lib/constructs/websocket.ts
@@ -109,7 +109,7 @@ export class WebSocket extends Construct {
       index: "app/websocket.py",
       bundling: {
         assetExcludes: [...excludeDockerImage],
-        buildArgs: { POETRY_VERSION: "1.8.3" },
+        buildArgs: { POETRY_VERSION: "1.8.5" },
       },
       runtime: Runtime.PYTHON_3_13,
       memorySize: 512,


### PR DESCRIPTION
## Summary

Pin Poetry to `1.8.5` everywhere it's installed for backend bundling. Two related problems get fixed:

- `cdk/lib/constructs/api.ts` and `cdk/lib/constructs/websocket.ts` hardcode `POETRY_VERSION: "1.8.3"` for `PythonFunction` bundling. Poetry 1.8.3 crashes with `Unknown metadata version: 2.4` when resolving transitive dependencies that ship the newer packaging metadata format, breaking fresh `cdk deploy`.
- `backend/Dockerfile` and `backend/lambda.Dockerfile` install Poetry without a version pin (`pip install poetry`), which currently resolves to Poetry 2.x and introduces breaking changes in lockfile and CLI behavior.

`1.8.5` is the latest 1.8.x and reads the existing `poetry.lock` without regeneration.

## Scope

- `poetry.lock` is **intentionally not regenerated** here — keeping the diff to 4 lines so it's reviewable in a glance and easy to bisect.
- This is split out from #1044 per reviewer feedback. The other two splits (CDK `tsconfig`, `serialize-javascript` override) will follow as separate PRs.

Refs #1035, supersedes part of #1044.

## Test plan

- [ ] `cdk deploy` succeeds end-to-end (CodeBuild path, fresh deploy)
- [ ] `docker build -f backend/Dockerfile backend/` completes
- [ ] `docker build -f backend/lambda.Dockerfile backend/` completes