### PR TITLE
chore(cdk): enable skipLibCheck and exclude lambda/ from root tsconfig

### DIFF
--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -20,12 +20,14 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
     ]
   },
   "exclude": [
     "node_modules",
-    "cdk.out"
+    "cdk.out",
+    "lambda"
   ]
 }


### PR DESCRIPTION
## Summary

Two small `cdk/tsconfig.json` changes that unblock `tsc --noEmit`:

- **`skipLibCheck: true`** — under TypeScript 5.x, the `effect` library's shipped `.d.ts` files reference `NoInfer` and use generic `Uint8Array` / `IterableIterator` forms that produce 30+ errors against the project's current `lib` target. These are third-party declarations the project doesn't control, so `skipLibCheck` is the standard escape hatch.
- **Exclude `lambda/`** — the `cdk/lambda/` tree ships its own `tsconfig.json` for the Lambda runtime context, so pulling it into the root project causes spurious type errors and double-compilation.

## Verification

Run from `cdk/`:

|  | `tsc --noEmit` errors |
|---|---|
| Before | 30+ (all from `node_modules/effect/dist/dts/*` and `cdk/lambda/`) |
| After  | 0 |

Confirmed `cdk synth` runs past the TypeScript phase unchanged (verified locally; Docker bundling not exercised in this environment but unrelated to the change).

The single string-path reference to the lambda tree at `cdk/lib/bedrock-shared-knowledge-bases-stack.ts:124` is a path passed to `NodejsFunction`'s `entry` — it's bundled by esbuild at deploy time, not type-checked by the root project, so the exclude is safe.

## Scope

Split out from #1044 per reviewer feedback. Refs #1035.

## Test plan

- [ ] `cd cdk && npx tsc --noEmit` exits 0
- [ ] `cd cdk && npx cdk synth` still succeeds