### PR TITLE
fix: remove trailing slash from cognitoDomain breaking OAuth code exchange

### DIFF
--- a/cdk/lib/constructs/frontend.ts
+++ b/cdk/lib/constructs/frontend.ts
@@ -194,7 +194,7 @@ export class Frontend extends Construct {
     idp: Idp;
   }) {
     const region = Stack.of(auth.userPool).region;
-    const cognitoDomain = `${userPoolDomainPrefix}.auth.${region}.amazoncognito.com/`;
+    const cognitoDomain = `${userPoolDomainPrefix}.auth.${region}.amazoncognito.com`;
     const buildEnvProps = (() => {
       const defaultProps = {
         VITE_APP_API_ENDPOINT: backendApiEndpoint,


### PR DESCRIPTION
Fixes #1116.

The Cognito domain in `cdk/lib/constructs/frontend.ts` is built with a trailing slash, so Amplify requests `//oauth2/token` (404 without CORS headers) and the authorization-code exchange fails in the browser for external OIDC providers.

One-line fix: drop the trailing slash. We have been running this as a build-time patch in our deployment (Microsoft Entra ID) and can confirm it fixes the login flow.