### PR TITLE
fix: map the standard OIDC email claim for external identity providers

### DIFF
--- a/cdk/lib/constructs/auth.ts
+++ b/cdk/lib/constructs/auth.ts
@@ -133,9 +133,9 @@ export class Auth extends Construct {
               clientSecret: clientSecret.unsafeUnwrap().toString(),
               issuerUrl,
               attributeMapping: {
-                // This is an example of mapping the email attribute.
-                // Replace this with the actual idp attribute key.
-                email: ProviderAttribute.other("EMAIL"),
+                // Standard OIDC claim name. Adjust if your IdP emits
+                // the email under a non-standard attribute key.
+                email: ProviderAttribute.other("email"),
               },
               scopes: ["openid", "email"],
             }


### PR DESCRIPTION
Fixes #1117.

`cdk/lib/constructs/auth.ts` maps the email attribute with a hardcoded placeholder key `"EMAIL"`. The OIDC Core standard claim name is lowercase `email`, which is what mainstream IdPs (Microsoft Entra ID, Okta, Auth0, Keycloak) emit, so the mapping silently fails out of the box, and since the OIDC configuration is otherwise context-driven there is no way to fix it without editing library source.

This changes the default to the standard claim and updates the comment accordingly. We have been running this as a build-time patch in our deployment with Microsoft Entra ID.