### PR TITLE
fix: add eu-central-2 to the claude-v4.5-haiku cross-region inference map

### DIFF
--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -376,6 +376,7 @@ REGIONAL_INFERENCE_PROFILES = {
             "ap-northeast-1": "jp",
             "ap-northeast-3": "jp",
             "eu-central-1": "eu",
+            "eu-central-2": "eu",
             "eu-north-1": "eu",
             "eu-west-1": "eu",
             "eu-west-3": "eu",


### PR DESCRIPTION
Fixes #1118.

`eu-central-2` is present in the base `supported_regions` list for `claude-v4.5-haiku` in `backend/app/bedrock.py`, but missing from the model's cross-region inference map, so the code falls back to the base model ID, which Bedrock rejects (Claude Haiku 4.5 is inference-profile only). The `eu.` CRIS profile for the model does include eu-central-2 (verified live).

One-line fix: add `"eu-central-2": "eu"` to the map. We have been running this as a build-time patch in our eu-central-2 deployment.