### PR TITLE
fix: read enableBotStoreReplicas context key with the correct case

### DIFF
--- a/cdk/lib/utils/parameter-models.ts
+++ b/cdk/lib/utils/parameter-models.ts
@@ -273,7 +273,7 @@ export function resolveBedrockChatParameters(
     alternateDomainName: app.node.tryGetContext("alternateDomainName"),
     hostedZoneId: app.node.tryGetContext("hostedZoneId"),
     enableBotStore: app.node.tryGetContext("enableBotStore"),
-    enableBotStoreReplicas: app.node.tryGetContext("EnableBotStoreReplicas"),
+    enableBotStoreReplicas: app.node.tryGetContext("enableBotStoreReplicas"),
     botStoreLanguage: app.node.tryGetContext("botStoreLanguage"),
     globalAvailableModels: app.node.tryGetContext("globalAvailableModels"),
     defaultModel: app.node.tryGetContext("defaultModel"),


### PR DESCRIPTION
Fixes #1119.

`cdk/lib/utils/parameter-models.ts` reads `tryGetContext("EnableBotStoreReplicas")` with a capitalized first letter, unlike every other context key, so a user setting `enableBotStoreReplicas` in `cdk.json` is silently ignored and the value always falls back to the default.

One-character fix to match the documented camelCase key.