### PR TITLE
feat: add Claude Opus 4.8 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ npm ci
   - `logoPath`: Relative path under `frontend/public` that points to the image displayed at the top of the application drawer.
     The following model IDs are supported (please make sure that they are also enabled in the Bedrock console under Model access in your deployment region):
 
-- **Claude Models:** `claude-v4-opus`, `claude-v4.1-opus`, `claude-v4.5-opus`, `claude-v4.6-opus`, `claude-v4.7-opus`, `claude-v4-sonnet`, `claude-v4.5-sonnet`, `claude-v4.6-sonnet`, `claude-v3.5-sonnet`, `claude-v3.5-sonnet-v2`, `claude-v3.7-sonnet`, `claude-v3.5-haiku`, `claude-v3-haiku`, `claude-v3-opus`
+- **Claude Models:** `claude-v4-opus`, `claude-v4.1-opus`, `claude-v4.5-opus`, `claude-v4.6-opus`, `claude-v4.7-opus`, `claude-v4.8-opus`, `claude-v4-sonnet`, `claude-v4.5-sonnet`, `claude-v4.6-sonnet`, `claude-v3.5-sonnet`, `claude-v3.5-sonnet-v2`, `claude-v3.7-sonnet`, `claude-v3.5-haiku`, `claude-v3-haiku`, `claude-v3-opus`
 - **Amazon Nova Models:** `amazon-nova-pro`, `amazon-nova-lite`, `amazon-nova-micro`
 - **Mistral Models:** `mistral-7b-instruct`, `mixtral-8x7b-instruct`, `mistral-large`, `mistral-large-2`
 - **DeepSeek Models:** `deepseek-r1`

--- a/backend/app/bedrock.py
+++ b/backend/app/bedrock.py
@@ -62,6 +62,7 @@ BASE_MODEL_IDS = {
     "claude-v4.5-opus": "anthropic.claude-opus-4-5-20251101-v1:0",
     "claude-v4.6-opus": "anthropic.claude-opus-4-6-v1",
     "claude-v4.7-opus": "anthropic.claude-opus-4-7",
+    "claude-v4.8-opus": "anthropic.claude-opus-4-8",
     "claude-v4-sonnet": "anthropic.claude-sonnet-4-20250514-v1:0",
     "claude-v4.5-sonnet": "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "claude-v4.6-sonnet": "anthropic.claude-sonnet-4-6",
@@ -201,6 +202,12 @@ GLOBAL_INFERENCE_PROFILES = {
             "ap-northeast-1",
         ]
     },
+    "claude-v4.8-opus": {
+        "supported_regions": [
+            "eu-central-2",
+            "eu-central-1",
+        ]
+    },
     "claude-v4-sonnet": {
         "supported_regions": [
             "us-west-2",
@@ -295,6 +302,17 @@ REGIONAL_INFERENCE_PROFILES = {
             "ap-northeast-3": "jp",
             "ap-southeast-2": "au",
             "ap-southeast-4": "au",
+        }
+    },
+    "claude-v4.8-opus": {
+        "supported_regions": {
+            "eu-central-1": "eu",
+            "eu-central-2": "eu",
+            "eu-north-1": "eu",
+            "eu-south-1": "eu",
+            "eu-south-2": "eu",
+            "eu-west-1": "eu",
+            "eu-west-3": "eu",
         }
     },
     "claude-v4.6-opus": {
@@ -570,6 +588,7 @@ def is_adaptive_thinking_model(model: type_model_name) -> bool:
         "claude-v4.6-opus",
         "claude-v4.6-sonnet",
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
     ]
 
 
@@ -579,6 +598,7 @@ def is_prefill_supported(model: type_model_name) -> bool:
         "claude-v4.6-opus",
         "claude-v4.6-sonnet",
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
     ]
 
 
@@ -588,6 +608,7 @@ def is_specify_both_temperature_and_top_p_supported(model: type_model_name) -> b
         "claude-v4.5-opus",
         "claude-v4.6-opus",
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
         "claude-v4.5-sonnet",
         "claude-v4.6-sonnet",
         "claude-v4.5-haiku",
@@ -598,6 +619,7 @@ def is_top_k_supported(model: type_model_name) -> bool:
     """Claude Opus 4.7+ deprecates top_k parameter."""
     return model not in [
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
     ]
 
 
@@ -605,6 +627,7 @@ def is_top_p_supported(model: type_model_name) -> bool:
     """Claude Opus 4.7+ deprecates top_p parameter."""
     return model not in [
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
     ]
 
 
@@ -612,6 +635,7 @@ def is_temperature_supported(model: type_model_name) -> bool:
     """Claude Opus 4.7+ deprecates temperature parameter."""
     return model not in [
         "claude-v4.7-opus",
+        "claude-v4.8-opus",
     ]
 
 
@@ -625,6 +649,7 @@ def is_prompt_caching_supported(
             "claude-v4.5-opus",
             "claude-v4.6-opus",
             "claude-v4.7-opus",
+            "claude-v4.8-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
             "claude-v4.6-sonnet",
@@ -641,6 +666,7 @@ def is_prompt_caching_supported(
             "claude-v4.5-opus",
             "claude-v4.6-opus",
             "claude-v4.7-opus",
+            "claude-v4.8-opus",
             "claude-v4-sonnet",
             "claude-v4.5-sonnet",
             "claude-v4.6-sonnet",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -87,6 +87,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.00625,
             "cache_read_input": 0.0005,
         },
+        "claude-v4.8-opus": {
+            "input": 0.005,
+            "output": 0.025,
+            "cache_write_input": 0.00625,
+            "cache_read_input": 0.0005,
+        },
         "claude-v4-sonnet": {
             "input": 0.003,
             "output": 0.015,
@@ -190,6 +196,12 @@ BEDROCK_PRICING = {
             "cache_write_input": 0.00625,
             "cache_read_input": 0.0005,
         },
+        "claude-v4.8-opus": {
+            "input": 0.005,
+            "output": 0.025,
+            "cache_write_input": 0.00625,
+            "cache_read_input": 0.0005,
+        },
         "claude-v4-sonnet": {
             "input": 0.003,
             "output": 0.015,
@@ -281,6 +293,12 @@ BEDROCK_PRICING = {
             "cache_read_input": 0.0005,
         },
         "claude-v4.7-opus": {
+            "input": 0.005,
+            "output": 0.025,
+            "cache_write_input": 0.00625,
+            "cache_read_input": 0.0005,
+        },
+        "claude-v4.8-opus": {
             "input": 0.005,
             "output": 0.025,
             "cache_write_input": 0.00625,

--- a/backend/app/routes/schemas/conversation.py
+++ b/backend/app/routes/schemas/conversation.py
@@ -11,6 +11,7 @@ type_model_name = Literal[
     "claude-v4.5-opus",
     "claude-v4.6-opus",
     "claude-v4.7-opus",
+    "claude-v4.8-opus",
     "claude-v4-sonnet",
     "claude-v4.5-sonnet",
     "claude-v4.6-sonnet",

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -87,6 +87,7 @@ export const AVAILABLE_MODEL_KEYS = [
   'claude-v4.5-opus',
   'claude-v4.6-opus',
   'claude-v4.7-opus',
+  'claude-v4.8-opus',
   'claude-v4-sonnet',
   'claude-v4.5-sonnet',
   'claude-v4.6-sonnet',

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -112,6 +112,13 @@ const useModel = (botId?: string | null, activeModels?: ActiveModels) => {
         supportReasoning: true,
       },
       {
+        modelId: 'claude-v4.8-opus',
+        label: t('model.claude-v4.8-opus.label'),
+        description: t('model.claude-v4.8-opus.description'),
+        supportMediaType: CLAUDE_SUPPORTED_MEDIA_TYPES,
+        supportReasoning: true,
+      },
+      {
         modelId: 'claude-v4-sonnet',
         label: t('model.claude-v4-sonnet.label'),
         description: t('model.claude-v4-sonnet.description'),

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -45,6 +45,11 @@ const translation = {
         description:
           'High-capability Opus model built for coding, enterprise workflows, and long-running agentic tasks.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'Most capable Opus model, built for long-running agentic tasks, coding, and enterprise workflows.',
+      },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',
         description:

--- a/frontend/src/i18n/es/index.ts
+++ b/frontend/src/i18n/es/index.ts
@@ -56,6 +56,11 @@ const translation = {
         description:
           'Modelo Opus de alta capacidad diseñado para codificación, flujos de trabajo empresariales y tareas de agente de larga duración.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'El modelo Opus más capaz, diseñado para tareas de agente de larga duración, codificación y flujos de trabajo empresariales.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo potente para tareas altamente complejas.',

--- a/frontend/src/i18n/id/index.ts
+++ b/frontend/src/i18n/id/index.ts
@@ -56,6 +56,11 @@ const translation = {
         description:
           'Model Opus berkemampuan tinggi yang dibuat untuk coding, alur kerja perusahaan, dan tugas agen jangka panjang.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'Model Opus paling mumpuni, dibuat untuk tugas agen jangka panjang, coding, dan alur kerja perusahaan.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Model yang kuat untuk tugas-tugas yang sangat kompleks.',

--- a/frontend/src/i18n/ja/index.ts
+++ b/frontend/src/i18n/ja/index.ts
@@ -48,6 +48,11 @@ const translation: typeof en = {
         description:
           'コーディング、エンタープライズワークフロー、長時間のエージェントタスク向けに構築された高性能Opusモデル。',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          '長時間のエージェントタスク、コーディング、エンタープライズワークフロー向けに構築された最も高性能なOpusモデル。',
+      },
       'claude-v4-sonnet': {
         label: 'Claude 4 (Sonnet)',
         description:

--- a/frontend/src/i18n/pl/index.ts
+++ b/frontend/src/i18n/pl/index.ts
@@ -56,6 +56,11 @@ const translation = {
         description:
           'Wysoko wydajny model Opus stworzony do kodowania, przepływów pracy w przedsiębiorstwach i długotrwałych zadań agentowych.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'Najbardziej zaawansowany model Opus, stworzony do długotrwałych zadań agentowych, kodowania i przepływów pracy w przedsiębiorstwach.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Potężny model do wysoce złożonych zadań.',

--- a/frontend/src/i18n/pt-br/index.ts
+++ b/frontend/src/i18n/pt-br/index.ts
@@ -63,6 +63,11 @@ const translation = {
         description:
           'Modelo Opus de alta capacidade criado para codificação, fluxos de trabalho empresariais e tarefas de agente de longa duração.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'O modelo Opus mais capaz, criado para tarefas de agente de longa duração, codificação e fluxos de trabalho empresariais.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Modelo poderoso para tarefas altamente complexas.',

--- a/frontend/src/i18n/vi/index.ts
+++ b/frontend/src/i18n/vi/index.ts
@@ -56,6 +56,11 @@ const translation = {
         description:
           'Mô hình Opus hiệu suất cao được xây dựng cho việc lập trình, quy trình doanh nghiệp và các tác vụ agent dài hạn.',
       },
+      'claude-v4.8-opus': {
+        label: 'Claude 4.8 (Opus)',
+        description:
+          'Mô hình Opus mạnh nhất, được xây dựng cho các tác vụ agent dài hạn, lập trình và quy trình doanh nghiệp.',
+      },
       'claude-v3-opus': {
         label: 'Claude 3 (Opus)',
         description: 'Mô hình mạnh mẽ cho các tác vụ cực kỳ phức tạp.',

--- a/scripts/cross_region_inference/get_supported_cross_region_inferences.py
+++ b/scripts/cross_region_inference/get_supported_cross_region_inferences.py
@@ -7,6 +7,7 @@ supported_base_models = {
     "anthropic.claude-opus-4-20250514-v1:0": "claude-v4-opus",
     "anthropic.claude-opus-4-6-v1": "claude-v4.6-opus",
     "anthropic.claude-opus-4-7": "claude-v4.7-opus",
+    "anthropic.claude-opus-4-8": "claude-v4.8-opus",
     "anthropic.claude-sonnet-4-20250514-v1:0": "claude-v4-sonnet",
     "anthropic.claude-sonnet-4-6": "claude-v4.6-sonnet",
     "anthropic.claude-3-haiku-20240307-v1:0": "claude-v3-haiku",


### PR DESCRIPTION
Closes #1124

Adds `claude-v4.8-opus` → `anthropic.claude-opus-4-8`, mirroring the Opus 4.7 addition (#1101) file-by-file (model map, inference maps, capability lists, pricing, schema literal, frontend constants + model hook + 7 i18n locales, README, cross-region script mapping).

### Behavior flags

Opus 4.8 keeps the exact 4.7 request surface, so it joins the same lists as `claude-v4.7-opus`:

- `is_adaptive_thinking_model` → yes (no `budget_tokens`)
- `is_prefill_supported` → no
- `is_top_k_supported` / `is_top_p_supported` / `is_temperature_supported` → no
- `is_specify_both_temperature_and_top_p_supported` → no
- prompt caching (system/message/tool) → yes

### Pricing

Same list price as 4.7 in all three pricing tables: input 0.005, output 0.025, cache write 0.00625, cache read 0.0005 (USD per 1K tokens).

### Inference profile regions — verified subset only

Region lists were verified live via `aws bedrock get-inference-profile` from an eu-central-2 deployment:

- `REGIONAL_INFERENCE_PROFILES`: the `eu.` profile covers eu-central-1/2, eu-north-1, eu-south-1/2, eu-west-1, eu-west-3. **eu-west-2 is intentionally absent** — unlike 4.7, the eu profile for 4.8 does not include it.
- `GLOBAL_INFERENCE_PROFILES`: verified as a source region in eu-central-1 and eu-central-2.

Our AWS org is restricted to EU regions, so I could not enumerate us/jp/au/apac coverage; rather than guessing, those geos are left out (the cross-region script mapping already includes the new model ID, so regenerating the full maps from an unrestricted account is one script run). Happy to extend the maps if a maintainer can share the script output.

### Testing

- Python syntax check clean on the touched backend files; frontend/i18n changes are mechanical mirrors of #1101.
- Model and inference profiles verified ACTIVE via AWS CLI (details in the linked issue).
