### PR TITLE
fix: stop offering end-of-life models for Advanced Parsing

### DIFF
--- a/backend/app/repositories/models/custom_bot_kb.py
+++ b/backend/app/repositories/models/custom_bot_kb.py
@@ -4,7 +4,7 @@ from hashlib import md5
 from app.routes.schemas.bot_kb import (
     type_kb_chunking_strategy,
     type_kb_embeddings_model,
-    type_kb_parsing_model,
+    type_kb_parsing_model_stored,
     type_kb_search_type,
     type_kb_web_crawling_scope,
     type_os_character_filter,
@@ -92,7 +92,7 @@ class BedrockKnowledgeBaseModel(BaseModel):
     knowledge_base_id: str | None = None
     exist_knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
-    parsing_model: type_kb_parsing_model = "disabled"
+    parsing_model: type_kb_parsing_model_stored = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
     web_crawling_filters: WebCrawlingFiltersModel = WebCrawlingFiltersModel(
         exclude_patterns=[], include_patterns=[]

--- a/backend/app/routes/schemas/bot_kb.py
+++ b/backend/app/routes/schemas/bot_kb.py
@@ -13,7 +13,15 @@ type_kb_chunking_strategy = Literal[
 ]
 type_kb_embeddings_model = Literal["titan_v2", "cohere_multilingual_v3"]
 type_kb_search_type = Literal["hybrid", "semantic"]
+# Only models that are still invocable on Bedrock are selectable.
+# claude-3-5-sonnet-v1 and claude-3-sonnet-v1 reached end of life and every
+# ingestion using them fails with a 404 from IngestKnowledgeBaseDocuments.
 type_kb_parsing_model = Literal[
+    "anthropic.claude-3-haiku-v1",
+    "disabled",
+]
+# Superset kept so bots created before the end-of-life cut still deserialize.
+type_kb_parsing_model_stored = Literal[
     "anthropic.claude-3-5-sonnet-v1",
     "anthropic.claude-3-haiku-v1",
     "anthropic.claude-3-sonnet-v1",
@@ -125,7 +133,7 @@ class BedrockKnowledgeBaseOutput(BaseSchema):
     knowledge_base_id: str | None = None
     exist_knowledge_base_id: str | None = None
     data_source_ids: list[str] | None = None
-    parsing_model: type_kb_parsing_model = "disabled"
+    parsing_model: type_kb_parsing_model_stored = "disabled"
     web_crawling_scope: type_kb_web_crawling_scope = "DEFAULT"
     web_crawling_filters: WebCrawlingFilters = WebCrawlingFilters(
         exclude_patterns=[], include_patterns=[]

--- a/cdk/lib/utils/bedrock-knowledge-base-args.ts
+++ b/cdk/lib/utils/bedrock-knowledge-base-args.ts
@@ -69,7 +69,13 @@ export const getParsingModel = (
   }
   switch (parsingModel) {
     case "anthropic.claude-3-5-sonnet-v1":
-      return BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_SONNET_V1_0;
+    case "anthropic.claude-3-sonnet-v1":
+      // End of life on Bedrock (ingestion fails with 404). Fall back to the
+      // remaining live parsing model so existing bots keep syncing.
+      console.warn(
+        `Parsing model ${parsingModel} reached end of life on Bedrock, falling back to Claude 3 Haiku.`
+      );
+      return BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0;
     case "anthropic.claude-3-haiku-v1":
       return BedrockFoundationModel.ANTHROPIC_CLAUDE_HAIKU_V1_0;
     case "disabled":

--- a/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
+++ b/frontend/src/features/knowledgeBase/pages/BotKbEditPage.tsx
@@ -334,13 +334,6 @@ const BotKbEditPage: React.FC = () => {
       description: t('knowledgeBaseSettings.parsingModel.none.hint'),
     },
     {
-      label: t('knowledgeBaseSettings.parsingModel.claude_3_5_sonnet_v1.label'),
-      value: 'anthropic.claude-3-5-sonnet-v1',
-      description: t(
-        'knowledgeBaseSettings.parsingModel.claude_3_5_sonnet_v1.hint'
-      ),
-    },
-    {
       label: t('knowledgeBaseSettings.parsingModel.claude_3_haiku_v1.label'),
       value: 'anthropic.claude-3-haiku-v1',
       description: t(

--- a/frontend/src/features/knowledgeBase/types/index.d.ts
+++ b/frontend/src/features/knowledgeBase/types/index.d.ts
@@ -16,7 +16,7 @@ export type BedrockKnowledgeBase = {
 
 export type EmbeddingsModel = 'titan_v2' | 'cohere_multilingual_v3';
 
-export type ParsingModel = 'anthropic.claude-3-5-sonnet-v1' | 'anthropic.claude-3-haiku-v1' | 'disabled';
+export type ParsingModel = 'anthropic.claude-3-haiku-v1' | 'disabled';
 
 export type ChunkingStrategy = 'default' | 'fixed_size' | 'hierarchical' | 'semantic' | 'none';
 


### PR DESCRIPTION
Mitigates #1126.

Two of the three selectable Advanced Parsing models (`anthropic.claude-3-5-sonnet-v1`, `anthropic.claude-3-sonnet-v1`) reached end of life on Bedrock, so selecting them makes every `IngestKnowledgeBaseDocuments` call fail with a 404 and the knowledge base silently ends up empty. Claude 3 Haiku is the only option still invocable.

### What this PR does

* Removes the two end-of-life models from the selectable options (backend create/update schema, frontend picker and type).
* Keeps the legacy values valid for **stored** bots: a separate `type_kb_parsing_model_stored` Literal is used by the repository model and the `BedrockKnowledgeBaseOutput` schema, so bots created before the cut still deserialize and GET responses do not break.
* In the CDK mapping, legacy values fall back to Claude 3 Haiku with a `console.warn`, so existing bots configured with an EOL model heal on their next sync instead of failing with the 404.

### What this PR deliberately does not do

Adding current-generation models is not a constant swap: every current Claude model on Bedrock is `INFERENCE_PROFILE`-only (no on-demand), so the parsing configuration needs inference-profile ARN support (plus the matching KB role permissions across the profile regions). That is proposed as the follow-up in #1126.

The now-unused i18n label keys for the removed option are left in place across locales to keep this diff minimal.

We run the equivalent behavior in our deployment; the "parsing disabled" workaround and the 404 root cause are confirmed there.
