### PR TITLE
fix: ingest file diffs for shared-KB bots updated outside the shared flow

### DIFF
--- a/backend/embedding_statemachine/bedrock_knowledge_base/finalize_custom_bot_build.py
+++ b/backend/embedding_statemachine/bedrock_knowledge_base/finalize_custom_bot_build.py
@@ -3,6 +3,7 @@ from typing import List, TypedDict
 
 import boto3
 from app.repositories.custom_bot import (
+    find_bot_by_id,
     update_knowledge_base_id,
     update_guardrails_params,
 )
@@ -100,6 +101,26 @@ def handler(event, context):
             for data_source_id in data_source_ids
         )
         update_knowledge_base_id(user_id, bot_id, knowledge_base_id, data_source_ids)
+
+    # Shared-KB bots updated outside the SharedKnowledgeBases flow carry no
+    # DataSources in the event, and their per-bot stack exposes no
+    # KnowledgeBaseId output, so their file diffs would silently never be
+    # ingested. Fall back to the Knowledge Base already recorded on the bot.
+    if not data_sources and bot_files_diffs:
+        knowledge_base = find_bot_by_id(bot_id).bedrock_knowledge_base
+        if (
+            knowledge_base
+            and knowledge_base.knowledge_base_id
+            and knowledge_base.data_source_ids
+        ):
+            data_sources.extend(
+                {
+                    "KnowledgeBaseId": knowledge_base.knowledge_base_id,
+                    "DataSourceId": data_source_id,
+                    "FilesDiffs": bot_files_diffs,
+                }
+                for data_source_id in knowledge_base.data_source_ids
+            )
 
     # Update `guardrail_arn` of the bot using dedicated Guardrail.
     guardrail_arn = stack_outputs.get("GuardrailArn")


### PR DESCRIPTION
Fixes #1129.

On the `MapQueuedBots` update path, a bot backed by a **shared** knowledge base reaches `finalize_custom_bot_build` with a valid `FilesDiff` but no `DataSources` in the event, and its per-bot `BrChatKbStack{botId}` exposes no `KnowledgeBaseId` output (that only exists for dedicated KBs). The handler therefore returned `DataSources: []`, the ingestion Map state iterated over zero items, and the sync finished `SUCCEEDED` while the added files were never ingested.

### What this PR does

When the handler has file diffs to process but ended up with no data sources, it falls back to the `knowledge_base_id` and `data_source_ids` that `update_knowledge_base_id()` already persisted on the bot record at creation time. Dedicated bots and the SharedKnowledgeBases creation flow are untouched (they populate `data_sources` before the fallback is consulted).

### Verified

Reproduced live on a v3.17.0 deployment: adding two PDFs to an existing shared-KB bot produced a successful sync with `DataSources: []` in the execution history and no new documents in the knowledge base. Ingesting the same two documents with the exact call this fallback generates (`IngestKnowledgeBaseDocuments` against the bot record's KB and data source) indexed them correctly and retrieval picked them up.
